### PR TITLE
Implement automatic selection of papers using large language models

### DIFF
--- a/search-judge/pyproject.toml
+++ b/search-judge/pyproject.toml
@@ -3,6 +3,8 @@ name = "mapwisefox-search-judge"
 version = "0.1.0"
 dependencies = [
     "bibtexparser>=1.4.3",
+    "jinja2>=3.1.6",
+    "ollama>=0.5.1",
     "openpyxl>=3.1.5",
     "pandas>=2.3.1",
 ]

--- a/search-judge/src/mapwisefox/search_judge/__main__.py
+++ b/search-judge/src/mapwisefox/search_judge/__main__.py
@@ -1,86 +1,10 @@
-import re
-from pathlib import Path
-
-import click
-import pandas as pd
-from bibtexparser import load as load_bibtex
-from bibtexparser.bparser import BibTexParser
+import importlib
+from ._base import search_judge
 
 
-def _read_bibliography(path):
-    with open(path) as bibtex_file:
-        parser = BibTexParser(common_strings=True)
-        bib_database = load_bibtex(bibtex_file, parser=parser)
-        records = [
-            {
-                "title": entry["title"],
-                "abstract": entry.get("abstract", ""),
-                "authors": entry.get("author", "").replace(" and", ";"),
-                "keywords": entry.get("keywords", "").replace(", ", "; "),
-                "source": entry.get("booktitle", entry.get("journal", "")),
-                "year": int(entry["year"]),
-                "doi": entry.get("doi", "N/A"),
-                "url": entry.get(
-                    "url",
-                    f"https://doi.org/{entry['doi']}" if "doi" in entry else "N/A",
-                ),
-            }
-            for entry in bib_database.entries
-        ]
-        return pd.DataFrame(records)
-
-
-def _load_df(path):
-    fh = {
-        ".bib": _read_bibliography,
-        ".xlsx": pd.read_excel,
-        ".csv": pd.read_csv,
-    }
-    file_loader = fh.get(path.suffix)
-    if not file_loader:
-        raise ValueError("unsupported file type", path.suffix)
-    return file_loader(path)
-
-
-@click.command()
-@click.argument(
-    "judgment_file",
-    type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True, resolve_path=True),
-    required=True,
-)
-@click.argument(
-    "search_results_file",
-    type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True, resolve_path=True),
-    required=True,
-)
-def main(judgment_file, search_results_file) -> None:
-    judgment_df = _load_df(Path(judgment_file)).fillna(value="")
-    search_results_df = _load_df(Path(search_results_file)).fillna(value="")
-
-    def _extract_str(record):
-        if "doi" in record and record["doi"] not in {"N/A", ""}:
-            return record["doi"].strip().lower()
-        title_str = record["title"].strip().lower()
-        title_str = re.sub(r"[{}:-]", "", title_str)
-        title_str = re.sub(r"(-|\s+)", "_", title_str)
-        year_str = str(record["year"])
-        return f"{year_str}_{title_str}"
-
-    judgment_df["compare_value"] = judgment_df.apply(_extract_str, axis=1)
-    search_results_df["compare_value"] = search_results_df.apply(_extract_str, axis=1)
-
-    tp_count = judgment_df.merge(search_results_df, on="compare_value", how="inner").shape[0]
-    mismatch = judgment_df.merge(search_results_df, on="compare_value", how="outer", indicator=True)
-    fp_count = mismatch[mismatch["_merge"] == "right_only"].shape[0]
-    fn_count = mismatch[mismatch["_merge"] == "left_only"].shape[0]
-
-    precision = tp_count / (tp_count + fp_count)
-    recall = tp_count / (tp_count + fn_count)
-    f1  = 2 * precision * recall / (precision + recall)
-
-    click.echo(f"Precision: {click.style(f'{precision:.2%}', bold=True)}", color=True)
-    click.echo(f"Recall:    {click.style(f'{recall:.2%}', bold=True)}", color=True)
-    click.echo(f"F1 Score:  {click.style(f'{f1:.2%}', bold=True)}", color=True)
+def main():
+    importlib.import_module("mapwisefox.search_judge._quality", None)
+    search_judge()
 
 
 if __name__ == "__main__":

--- a/search-judge/src/mapwisefox/search_judge/__main__.py
+++ b/search-judge/src/mapwisefox/search_judge/__main__.py
@@ -4,6 +4,7 @@ from ._base import search_judge
 
 def main():
     importlib.import_module("mapwisefox.search_judge._quality", None)
+    importlib.import_module("mapwisefox.search_judge._llm", None)
     search_judge()
 
 

--- a/search-judge/src/mapwisefox/search_judge/_base.py
+++ b/search-judge/src/mapwisefox/search_judge/_base.py
@@ -1,0 +1,7 @@
+import click
+
+
+@click.group()
+@click.pass_context
+def search_judge(ctx):
+    """Commands for judging the results of a search from various perspectives."""

--- a/search-judge/src/mapwisefox/search_judge/_llm.py
+++ b/search-judge/src/mapwisefox/search_judge/_llm.py
@@ -1,0 +1,118 @@
+import json
+import os
+from itertools import islice
+from json import JSONDecodeError
+from pathlib import Path
+
+import click
+from jinja2 import FileSystemLoader, Environment
+from ollama import Client
+
+from ._base import search_judge
+from ._utils import load_df
+
+SYSTEM_PROMPT_TEMPLATE_NAME = "_llm_system_prompt.j2"
+
+
+def _new_connection(host, port):
+    return Client(f"{host}:{port}")
+
+
+def _load_system_prompt_template():
+    loader = FileSystemLoader(Path(__file__).parent)
+    env = Environment(loader=loader)
+    tpl = env.get_template(SYSTEM_PROMPT_TEMPLATE_NAME)
+    return tpl
+
+
+def _generate(client, rule_config, model, title_abs):
+    tpl = _load_system_prompt_template()
+    system_prompt = tpl.render(**rule_config)
+    response = client.generate(model=model, prompt=title_abs, system=system_prompt)
+    return response.response
+
+
+@search_judge.command()
+@click.argument(
+    "search_results",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True),
+)
+@click.option(
+    "-c", "--config-file",
+    type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True),
+    required=True,
+    help="path to a JSON configuration containing inclusion and exclusion criteria",
+)
+@click.option(
+    "-m", "--model",
+    type=click.Choice(["llama3.1", "command-r7b", "gemma3n", "deepseek-r1:14b"]),
+    default="llama3.1",
+    help="the name of the large language model to use",
+    show_default=True,
+)
+@click.option(
+    "--ollama-host",
+    type=click.STRING,
+    default="localhost",
+    help="host running Ollama",
+    show_default=True,
+)
+@click.option(
+    "--ollama-port",
+    type=click.IntRange(1024, 65535, clamp=True),
+    default=11434,
+    help="port on which Ollama is listening",
+    show_default=True,
+)
+@click.option(
+    "--limit",
+    type=click.INT,
+    default=None,
+    help="maximum number of results to process",
+    required=False,
+)
+def llm(search_results, config_file, model, ollama_host, ollama_port, limit):
+    """Use a large language model to filter out irrelevant search results."""
+    DEFAULT_EXCLUDED_ATTRIBUTES = {"cluster_id", "include", "exclude_reason"}
+    search_results_path = Path(search_results)
+    results_df = load_df(search_results_path)
+    with open(config_file, "r") as f:
+        rule_config = json.load(f)
+    ollama_client = _new_connection(ollama_host, ollama_port)
+
+    count = len(results_df) if limit is None else limit
+    items = islice(results_df.iterrows(), 0, count)
+
+    with click.progressbar(
+        items,
+        length=count,
+        label="processing search results",
+        fill_char=click.style("#", fg="green"),
+        empty_char=click.style("-", fg="white", dim=True),
+    ) as df_rows:
+        for ix, row in df_rows:
+            row_str = os.linesep.join(
+                f"{key}: {value}"
+                for key, value in row.items()
+                if key not in DEFAULT_EXCLUDED_ATTRIBUTES
+            )
+            answered = False
+            answer_obj = {}
+            while not answered and (answer := _generate(ollama_client, rule_config, model, row_str)):
+                try:
+                    answer_obj = json.loads(answer)
+                    answered = True
+                except JSONDecodeError as err:
+                    click.echo(err, err=True)
+            status = answer_obj["answer"]
+            results_df.at[ix, "include"] = status
+
+            if status == "exclude":
+                results_df.at[ix, "exclude_reason"] = answer_obj["justification"]
+            elif status == "include":
+                results_df.at[ix, "exclude_reason"] = ""
+
+    output_path = search_results_path.parent / f"{search_results_path.stem}-llm.xlsx"
+    results_df.to_excel(output_path, index=False)
+    click.echo(f"saved results to {click.style(output_path, bold=True)}", color=True, err=False)

--- a/search-judge/src/mapwisefox/search_judge/_llm_system_prompt.j2
+++ b/search-judge/src/mapwisefox/search_judge/_llm_system_prompt.j2
@@ -1,0 +1,33 @@
+# Role
+
+You select primary studies which are suitable for writing a secondary study
+based on their title and abstract alone. You meticulously apply the selection
+criteria to select the best studies for your objective.
+
+# Objective
+
+{{ study_objective }}
+
+# Selection Criteria
+
+## Inclusion
+{% for criterion in inclusion_criteria %}
+* {{ criterion }}{% endfor %}
+
+## Exclusion
+{% for criterion in exclusion_criteria %}
+* {{ criterion }}{% endfor %}
+
+# Output
+
+Your answer is one of "include" or "exclude". You must present your answer as
+valid JSON. The answer must be presented in a property called "answer".
+If the answer is "exclude", a brief justification must be provided in a second
+property called "justification". The justification must highlight the most
+important violation of the selection criteria.
+
+Example formatting of answers:
+
+{"answer": "include"}
+
+{"answer": "exclude", "justification": "not written in English"}

--- a/search-judge/src/mapwisefox/search_judge/_quality.py
+++ b/search-judge/src/mapwisefox/search_judge/_quality.py
@@ -1,0 +1,109 @@
+import re
+from pathlib import Path
+
+import click
+import pandas as pd
+from bibtexparser import load as load_bibtex
+from bibtexparser.bparser import BibTexParser
+
+from ._base import search_judge
+
+
+def _read_bibliography(path):
+    with open(path) as bibtex_file:
+        parser = BibTexParser(common_strings=True)
+        bib_database = load_bibtex(bibtex_file, parser=parser)
+        records = [
+            {
+                "title": entry["title"],
+                "abstract": entry.get("abstract", ""),
+                "authors": entry.get("author", "").replace(" and", ";"),
+                "keywords": entry.get("keywords", "").replace(", ", "; "),
+                "source": entry.get("booktitle", entry.get("journal", "")),
+                "year": int(entry["year"]),
+                "doi": entry.get("doi", "N/A"),
+                "url": entry.get(
+                    "url",
+                    f"https://doi.org/{entry['doi']}" if "doi" in entry else "N/A",
+                ),
+            }
+            for entry in bib_database.entries
+        ]
+        return pd.DataFrame(records)
+
+
+def _load_df(path):
+    fh = {
+        ".bib": _read_bibliography,
+        ".xlsx": pd.read_excel,
+        ".csv": pd.read_csv,
+    }
+    file_loader = fh.get(path.suffix)
+    if not file_loader:
+        raise ValueError("unsupported file type", path.suffix)
+    return file_loader(path)
+
+
+@search_judge.command()
+@click.argument(
+    "judgment_file",
+    type=click.Path(
+        exists=True, dir_okay=False, file_okay=True, readable=True, resolve_path=True
+    ),
+    required=True,
+)
+@click.argument(
+    "search_results_file",
+    type=click.Path(
+        exists=True, dir_okay=False, file_okay=True, readable=True, resolve_path=True
+    ),
+    required=True,
+)
+def quality(judgment_file, search_results_file) -> None:
+    """Judge the quality of the search results against a judgment file.
+
+    The judgment file must be crafted and supplied in advance. This quality
+    verification technique originates in information retrieval where judgment
+    files are often used in the context of tuning a search engine's signal/noise
+    ratio.
+
+    \b
+    Args:
+        judgment_file: file containing known good papers in either ``.bib``
+            ``.csv`` or ``.xlsx`` format.
+        search_results_file: file containing search results in ``.bib``,
+            ``.csv`` or ``.xlsx`` format.
+    Returns:
+        precision, recall, f1 score
+    """
+    judgment_df = _load_df(Path(judgment_file)).fillna(value="")
+    search_results_df = _load_df(Path(search_results_file)).fillna(value="")
+
+    def _extract_str(record):
+        if "doi" in record and record["doi"] not in {"N/A", ""}:
+            return record["doi"].strip().lower()
+        title_str = record["title"].strip().lower()
+        title_str = re.sub(r"[{}:-]", "", title_str)
+        title_str = re.sub(r"(-|\s+)", "_", title_str)
+        year_str = str(record["year"])
+        return f"{year_str}_{title_str}"
+
+    judgment_df["compare_value"] = judgment_df.apply(_extract_str, axis=1)
+    search_results_df["compare_value"] = search_results_df.apply(_extract_str, axis=1)
+
+    tp_count = judgment_df.merge(
+        search_results_df, on="compare_value", how="inner"
+    ).shape[0]
+    mismatch = judgment_df.merge(
+        search_results_df, on="compare_value", how="outer", indicator=True
+    )
+    fp_count = mismatch[mismatch["_merge"] == "right_only"].shape[0]
+    fn_count = mismatch[mismatch["_merge"] == "left_only"].shape[0]
+
+    precision = tp_count / (tp_count + fp_count)
+    recall = tp_count / (tp_count + fn_count)
+    f1 = 2 * precision * recall / (precision + recall)
+
+    click.echo(f"Precision: {click.style(f'{precision:.2%}', bold=True)}", color=True)
+    click.echo(f"Recall:    {click.style(f'{recall:.2%}', bold=True)}", color=True)
+    click.echo(f"F1 Score:  {click.style(f'{f1:.2%}', bold=True)}", color=True)

--- a/search-judge/src/mapwisefox/search_judge/_utils.py
+++ b/search-judge/src/mapwisefox/search_judge/_utils.py
@@ -1,0 +1,49 @@
+import pandas as pd
+from bibtexparser import load as load_bibtex
+from bibtexparser.bparser import BibTexParser
+
+
+def _read_bibliography(path):
+    with open(path) as bibtex_file:
+        parser = BibTexParser(common_strings=True)
+        bib_database = load_bibtex(bibtex_file, parser=parser)
+        records = [
+            {
+                "title": entry["title"],
+                "abstract": entry.get("abstract", ""),
+                "authors": entry.get("author", "").replace(" and", ";"),
+                "keywords": entry.get("keywords", "").replace(", ", "; "),
+                "source": entry.get("booktitle", entry.get("journal", "")),
+                "year": int(entry["year"]),
+                "doi": entry.get("doi", "N/A"),
+                "url": entry.get(
+                    "url",
+                    f"https://doi.org/{entry['doi']}" if "doi" in entry else "N/A",
+                ),
+            }
+            for entry in bib_database.entries
+        ]
+        return pd.DataFrame(records)
+
+
+def load_df(path):
+    """Load a ``.bib``, ``.csv`` or ``.xlsx`` file into a pandas DataFrame.
+
+    Args:
+        path: path to ``.bib`` or ``.csv`` or ``.xlsx`` file
+
+    Raises:
+        ValueError: if ``path`` is not a ``.csv`` or ``.xlsx`` file
+
+    Returns:
+        ``pandas.DataFrame`` containing bibliography data
+    """
+    fh = {
+        ".bib": _read_bibliography,
+        ".xlsx": pd.read_excel,
+        ".csv": pd.read_csv,
+    }
+    file_loader = fh.get(path.suffix)
+    if not file_loader:
+        raise ValueError("unsupported file type", path.suffix)
+    return file_loader(path)

--- a/uv.lock
+++ b/uv.lock
@@ -598,6 +598,8 @@ version = "0.1.0"
 source = { editable = "search-judge" }
 dependencies = [
     { name = "bibtexparser" },
+    { name = "jinja2" },
+    { name = "ollama" },
     { name = "openpyxl" },
     { name = "pandas" },
 ]
@@ -605,6 +607,8 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "bibtexparser", specifier = ">=1.4.3" },
+    { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "ollama", specifier = ">=0.5.1" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pandas", specifier = ">=2.3.1" },
 ]
@@ -759,6 +763,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/8a/ccdf201457ed8ac6245187850aff4ca56a79edbea4829f4e9f14d46fa9a5/numpy-2.3.1-cp313-cp313t-win32.whl", hash = "sha256:6269b9edfe32912584ec496d91b00b6d34282ca1d07eb10e82dfc780907d6c2e", size = 6440678 },
     { url = "https://files.pythonhosted.org/packages/f1/7e/7f431d8bd8eb7e03d79294aed238b1b0b174b3148570d03a8a8a8f6a0da9/numpy-2.3.1-cp313-cp313t-win_amd64.whl", hash = "sha256:2a809637460e88a113e186e87f228d74ae2852a2e0c44de275263376f17b5bdc", size = 12870697 },
     { url = "https://files.pythonhosted.org/packages/d4/ca/af82bf0fad4c3e573c6930ed743b5308492ff19917c7caaf2f9b6f9e2e98/numpy-2.3.1-cp313-cp313t-win_arm64.whl", hash = "sha256:eccb9a159db9aed60800187bc47a6d3451553f0e1b08b068d8b277ddfbb9b244", size = 10260376 },
+]
+
+[[package]]
+name = "ollama"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/96/c7fe0d2d1b3053be614822a7b722c7465161b3672ce90df71515137580a0/ollama-0.5.1.tar.gz", hash = "sha256:5a799e4dc4e7af638b11e3ae588ab17623ee019e496caaf4323efbaa8feeff93", size = 41112 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/76/3f96c8cdbf3955d7a73ee94ce3e0db0755d6de1e0098a70275940d1aff2f/ollama-0.5.1-py3-none-any.whl", hash = "sha256:4c8839f35bc173c7057b1eb2cbe7f498c1a7e134eafc9192824c8aecb3617506", size = 13369 },
 ]
 
 [[package]]


### PR DESCRIPTION
The code uses Ollama to connect to and use a large language model to select primary studies to include in a systematic literature review. The rationale here is to have an un-opinionated judge of the selection, not to bypass the selection made by the team conducting the survey.


