### PR TITLE
remove reference to invalid urlencode jinja2 filter

### DIFF
--- a/web/src/mapwisefox/web/controller/_evidence.py
+++ b/web/src/mapwisefox/web/controller/_evidence.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 from pathlib import Path
 from threading import RLock
+from urllib.parse import urlencode
 
 import numpy as np
 import pandas as pd
@@ -150,6 +151,13 @@ def show_form(
     current_record_obj["exclude_reason"] = current_record_obj["exclude_reason"] or ""
     current_record_obj["exclude_reason"] = current_record_obj["exclude_reason"].split(
         ", "
+    )
+    current_record_obj["url"] = current_record_obj["url"] or (
+        "https://www.semanticscholar.org/search?{}".format(
+            urlencode({
+                "q": current_record_obj["title"],
+            })
+        )
     )
     return templates.TemplateResponse(
         "form.j2",

--- a/web/src/mapwisefox/web/view/templates/form.j2
+++ b/web/src/mapwisefox/web/view/templates/form.j2
@@ -18,7 +18,7 @@
     <div class="article-info">
         <div class="source-container">
             Source: <a
-                href="{{ record.url or "https://scholar.google.com?q={}".format(urlencode(record.title)) }}">{{ record.source }}</a>
+                href="{{ record.url or "#" }}">{{ record.source }}</a>
             <small style="font-size: 9px; margin: 2px;"><b>DOI:</b>{{ record.doi or "n/a" }}</small>
         </div>
         <div class="abstract-label"><b>Abstract</b></div>


### PR DESCRIPTION
- jinja2 does not have a built-in urlencode filter
- move the url composition logic to the controller because this is a one-off and implementing a reusable component would be overengineering at this point