### PR TITLE
hotfix: allow excluding studies without reason

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1721,7 +1721,7 @@ requires-dist = [
 
 [[package]]
 name = "mapwisefox-web-backend"
-version = "0.8.1.dev1"
+version = "0.8.2.dev1"
 source = { editable = "web/backend" }
 dependencies = [
     { name = "arrow" },

--- a/uv.lock
+++ b/uv.lock
@@ -1721,7 +1721,7 @@ requires-dist = [
 
 [[package]]
 name = "mapwisefox-web-backend"
-version = "0.8.2.dev1"
+version = "0.8.2"
 source = { editable = "web/backend" }
 dependencies = [
     { name = "arrow" },

--- a/web/backend/pyproject.toml
+++ b/web/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "mapwisefox-web-backend"
-version = "0.8.2-dev1"
+version = "0.8.2"
 dependencies = [
     "arrow>=1.3.0",
     "authlib>=1.6.0",
@@ -32,7 +32,7 @@ module-name = "mapwisefox.web"
 namespace = true
 
 [tool.bumpversion]
-current_version = "0.8.2-dev1"
+current_version = "0.8.2"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/web/backend/pyproject.toml
+++ b/web/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "mapwisefox-web-backend"
-version = "0.8.1"
+version = "0.8.2-dev1"
 dependencies = [
     "arrow>=1.3.0",
     "authlib>=1.6.0",
@@ -32,7 +32,7 @@ module-name = "mapwisefox.web"
 namespace = true
 
 [tool.bumpversion]
-current_version = "0.8.1"
+current_version = "0.8.2-dev1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/web/backend/src/mapwisefox/web/api/workbooks/_collection.py
+++ b/web/backend/src/mapwisefox/web/api/workbooks/_collection.py
@@ -77,9 +77,14 @@ async def import_workbook(
             config.exclusion_reason_column,
             "exclusionReasonColumn",
         )
-        selection_criteria = (
-            _validate_selection_criteria(selection_criteria_file)
+        selection_criteria_file_content = (
+            await selection_criteria_file.read()
             if selection_criteria_file is not None
+            else None
+        )
+        selection_criteria = (
+            _validate_selection_criteria(selection_criteria_file_content)
+            if selection_criteria_file_content
             else None
         )
         upload_dir.mkdir(parents=True, exist_ok=True)

--- a/web/backend/src/mapwisefox/web/api/workbooks/_models.py
+++ b/web/backend/src/mapwisefox/web/api/workbooks/_models.py
@@ -16,9 +16,7 @@ class ScreeningPatch(BaseModel):
 
     @model_validator(mode="after")
     def validate_excluded(self):
-        if self.decision == "excluded" and not any(
-            reason.strip() for reason in self.exclusion_reasons
-        ):
+        if self.decision == "excluded" and not self.exclusion_reasons:
             raise ValueError("Excluded records require at least one exclusion reason")
         return self
 

--- a/web/backend/src/mapwisefox/web/api/workbooks/_utils.py
+++ b/web/backend/src/mapwisefox/web/api/workbooks/_utils.py
@@ -2,7 +2,7 @@ import csv
 import json
 from pathlib import Path
 
-from fastapi import HTTPException, UploadFile
+from fastapi import HTTPException
 from pydantic import ValidationError
 
 from mapwisefox.common.config import SelectionConfig
@@ -58,9 +58,9 @@ def _raise_http(error: Exception) -> None:
     raise error
 
 
-def _validate_selection_criteria(file: UploadFile) -> SelectionConfig | None:
+def _validate_selection_criteria(content: bytes) -> SelectionConfig | None:
     try:
-        payload = json.loads(file.file.read())
+        payload = json.loads(content)
     except (json.JSONDecodeError, UnicodeDecodeError) as error:
         raise HTTPException(
             status_code=422,

--- a/web/backend/tests/mapwisefox/test_web/api/test_api.py
+++ b/web/backend/tests/mapwisefox/test_web/api/test_api.py
@@ -13,7 +13,7 @@ def client(tmp_path):
     app = FastAPI()
     app.include_router(auth_api_router)
     app.include_router(config_api_router)
-    config = AppSettings(uploads_dir=tmp_path)
+    config = AppSettings(uploads_dir=tmp_path, auth_enabled=False)
     app.dependency_overrides[current_user] = lambda: None
     app.dependency_overrides[user_upload_dir] = lambda: tmp_path
     app.dependency_overrides[settings] = lambda: config

--- a/web/backend/tests/mapwisefox/test_web/api/workbooks/test_collection.py
+++ b/web/backend/tests/mapwisefox/test_web/api/workbooks/test_collection.py
@@ -62,6 +62,21 @@ def test_import_accepts_upload_without_selection_criteria(client, workbook_file)
     assert screening["selectionCriteria"] is None
 
 
+def test_import_accepts_empty_selection_criteria_file(client, workbook_file):
+    response = client.post(
+        "/api/v1/workbooks",
+        files={
+            "file": ("studies.xlsx", workbook_file),
+            "selectionCriteria": ("", b""),
+        },
+        data={"worksheetName": "Studies", "expectedColumns": "title,abstract"},
+    )
+
+    assert response.status_code == 201
+    screening = client.get("/api/v1/workbooks/studies.xlsx/screening/0").json()
+    assert screening["selectionCriteria"] is None
+
+
 def test_import_rejects_malformed_selection_criteria_json(client, workbook_file):
     response = client.post(
         "/api/v1/workbooks",

--- a/web/frontend/.bumpversion.toml
+++ b/web/frontend/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.8.0"
+current_version = "0.8.1-dev1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/web/frontend/.bumpversion.toml
+++ b/web/frontend/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.8.1-dev1"
+current_version = "0.8.1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mapwisefox-web-frontend",
-  "version": "0.8.0",
+  "version": "0.8.1-dev1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mapwisefox-web-frontend",
-      "version": "0.8.0",
+      "version": "0.8.1-dev1",
       "dependencies": {
         "lucide-react": "^0.542.0",
         "react": "^19.1.1",

--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mapwisefox-web-frontend",
-  "version": "0.8.1-dev1",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mapwisefox-web-frontend",
-      "version": "0.8.1-dev1",
+      "version": "0.8.1",
       "dependencies": {
         "lucide-react": "^0.542.0",
         "react": "^19.1.1",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapwisefox-web-frontend",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1-dev1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapwisefox-web-frontend",
   "private": true,
-  "version": "0.8.1-dev1",
+  "version": "0.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/frontend/src/components/InclusionStatus.test.tsx
+++ b/web/frontend/src/components/InclusionStatus.test.tsx
@@ -8,10 +8,18 @@ describe("InclusionStatus", () => {
         expect(screen.getByRole("button", {name: "Include"})).toBeInTheDocument();
     });
 
-    it("renders exclusion reasons and empty reason state", () => {
-        const {rerender} = render(<InclusionStatus include={false} excludeReasons={["not software"]}/>);
+    it("renders exclusion reasons when present", () => {
+        render(<InclusionStatus include={false} excludeReasons={["not software"]}/>);
         expect(screen.getByText("not software")).toBeInTheDocument();
-        rerender(<InclusionStatus include="exclude" excludeReasons={[]}/>);
-        expect(screen.getByText("-")).toBeInTheDocument();
+    });
+
+    it("hides reasons section when only blank reasons are present", () => {
+        render(<InclusionStatus include="exclude" excludeReasons={[""]}/>);
+        expect(screen.queryByText("Reasons:")).not.toBeInTheDocument();
+    });
+
+    it("renders empty reason placeholder when no reasons are provided", () => {
+        render(<InclusionStatus include="exclude" excludeReasons={[]}/>);
+        expect(screen.queryByText("Reasons:")).not.toBeInTheDocument();
     });
 });

--- a/web/frontend/src/components/InclusionStatus.tsx
+++ b/web/frontend/src/components/InclusionStatus.tsx
@@ -14,22 +14,19 @@ export default function InclusionStatus({include, excludeReasons}: InclusionStat
             </div>
         )
     } else {
-        const reasons = Array.isArray(excludeReasons) ? excludeReasons : [];
+        const reasons = (Array.isArray(excludeReasons) ? excludeReasons : []).filter(Boolean);
         return (
             <div className={styles.panel}>
                 <button type="submit" className={styles.btnExclude}>Exclude</button>
-                <div className={styles.reasons}>
+                {reasons.length > 0 && <div className={styles.reasons}>
                     <span className={styles.reasonsHeading}>Reasons:</span>
-                    {reasons.length > 0 ? (
-                        <ul className={styles.reasonList}>
-                            {reasons.map((r, idx) => (
-                                <li key={idx} className={styles.reasonItem}>{r}</li>
-                            ))}
-                        </ul>
-                    ) : (<span className={styles.noReasons}>-</span>)}
-                </div>
+                    <ul className={styles.reasonList}>
+                        {reasons.map((r, idx) => (
+                            <li key={idx} className={styles.reasonItem}>{r}</li>
+                        ))}
+                    </ul>
+                </div>}
             </div>
-        )
-            ;
+        );
     }
 }

--- a/web/frontend/src/components/SelectionCriteriaForm.test.tsx
+++ b/web/frontend/src/components/SelectionCriteriaForm.test.tsx
@@ -54,11 +54,17 @@ describe("selection criteria", () => {
         expect(screen.getByRole("button", {name: "Include"})).toBeInTheDocument();
     });
 
-    it("renders no criteria lists when criteria is null", () => {
-        render(<SelectionCriteriaForm evidence={evidence} fileName="study.xlsx" criteria={null} onFormSubmit={vi.fn()}/>);
+    it("uses a default inclusion criterion when criteria is null", async () => {
+        const user = userEvent.setup();
+        const submit = vi.fn().mockResolvedValue(undefined);
+        render(<SelectionCriteriaForm evidence={evidence} fileName="study.xlsx" criteria={null} onFormSubmit={submit}/>);
 
-        expect(screen.queryByText("Inclusion Criteria")).not.toBeInTheDocument();
-        expect(screen.queryByText("Exclusion Criteria")).not.toBeInTheDocument();
+        expect(screen.getByLabelText("study meets selection criteria")).toBeInTheDocument();
+        await user.click(screen.getByLabelText("study meets selection criteria"));
+        expect(screen.getByRole("button", {name: "Exclude"})).toBeInTheDocument();
+        await user.click(screen.getByRole("button", {name: "Exclude"}));
+
+        expect(submit).toHaveBeenCalledWith({include: false, excludeReasons: [""]});
     });
 
     it("unchecking an inclusion criterion excludes the record", async () => {

--- a/web/frontend/src/components/SelectionCriteriaForm.tsx
+++ b/web/frontend/src/components/SelectionCriteriaForm.tsx
@@ -5,6 +5,13 @@ import "../styles/form.css";
 import type {EvidenceViewModel} from "../models/viewmodel.ts";
 import type {SelectionConfig} from "../models/transfer.ts";
 
+const defaultCriteria: SelectionConfig = {
+    review_topic: "",
+    additional_context: null,
+    inclusion_criteria: [{label: "", description: "study meets selection criteria"}],
+    exclusion_criteria: [],
+};
+
 export type IncludeStatusArgs = {
     include: boolean,
     excludeReasons: string[]
@@ -18,6 +25,7 @@ type SelectionCriteriaFormProps = {
 }
 
 export function SelectionCriteriaForm({evidence, criteria, onFormSubmit}: SelectionCriteriaFormProps) {
+    const effectiveCriteria = criteria ?? defaultCriteria;
     const [include, setInclude] = useState(evidence.include)
     const [excludeReasons, setExcludeReasons] = useState<string[]>(evidence.excludeReasons)
 
@@ -54,21 +62,21 @@ export function SelectionCriteriaForm({evidence, criteria, onFormSubmit}: Select
     return (
         <form className="criteria-form" onSubmit={submitData}>
             <InclusionStatus include={include} excludeReasons={excludeReasons} />
-            {criteria && <>
-                <h3>Inclusion Criteria</h3>
-                <ul>
-                    {criteria.inclusion_criteria.map((criterion, i) =>
-                        <SelectionCriterion key={`include_${i}`} evidence={evidence} criterionId={`include_${i}`}
-                                   criterionType="include"
-                                   excludeReason={criterion.label}
-                                   onStatusChanged={handleIncludeStatusChanged}>
-                            {criterion.description}
-                        </SelectionCriterion>
-                    )}
-                </ul>
+            <h3>Inclusion Criteria</h3>
+            <ul>
+                {effectiveCriteria.inclusion_criteria.map((criterion, i) =>
+                    <SelectionCriterion key={`include_${i}`} evidence={evidence} criterionId={`include_${i}`}
+                               criterionType="include"
+                               excludeReason={criterion.label}
+                               onStatusChanged={handleIncludeStatusChanged}>
+                        {criterion.description}
+                    </SelectionCriterion>
+                )}
+            </ul>
+            {effectiveCriteria.exclusion_criteria.length > 0 && <>
                 <h3>Exclusion Criteria</h3>
                 <ul>
-                    {criteria.exclusion_criteria.map((criterion, i) =>
+                    {effectiveCriteria.exclusion_criteria.map((criterion, i) =>
                         <SelectionCriterion key={`exclude_${i}`} evidence={evidence} criterionId={`exclude_${i}`}
                                    criterionType="exclude"
                                    excludeReason={criterion.label}

--- a/web/frontend/src/pages/EvidenceEditor.integration.test.tsx
+++ b/web/frontend/src/pages/EvidenceEditor.integration.test.tsx
@@ -98,12 +98,12 @@ describe("EvidenceEditor", () => {
         expect(await screen.findByRole("heading", {name: /\[1\].*Study 1/})).toBeInTheDocument();
     });
 
-    it("omits the criteria lists when the workbook has none", async () => {
+    it("shows a default inclusion criterion when the workbook has none", async () => {
         vi.mocked(getScreening).mockResolvedValue(screening(0, "Study 0", false));
         render(<EvidenceEditor evidence={screening(0, "Study 0", false).evidence} fileName="study.xlsx"/>);
 
         await screen.findByRole("heading", {name: /\[0\].*Study 0/});
-        expect(screen.queryByText("Inclusion Criteria")).not.toBeInTheDocument();
+        expect(screen.getByLabelText("study meets selection criteria")).toBeInTheDocument();
     });
 
     it("saves a decision and reports persistence errors", async () => {


### PR DESCRIPTION
Studies couldn't be excluded anymore when the user didn't provide selection criteria. Instead, allow excluding them with the blank reason.

- bump web-frontend version: 0.8.0 → 0.8.1
- bump web-backend version: 0.8.1 → 0.8.2