### PR TITLE
show exclusion reasons in the UI even if no selection criteria were specified

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1721,7 +1721,7 @@ requires-dist = [
 
 [[package]]
 name = "mapwisefox-web-backend"
-version = "0.9.0.dev1"
+version = "0.9.1.dev1"
 source = { editable = "web/backend" }
 dependencies = [
     { name = "arrow" },

--- a/uv.lock
+++ b/uv.lock
@@ -1721,7 +1721,7 @@ requires-dist = [
 
 [[package]]
 name = "mapwisefox-web-backend"
-version = "0.9.1.dev1"
+version = "0.9.1"
 source = { editable = "web/backend" }
 dependencies = [
     { name = "arrow" },

--- a/web/backend/pyproject.toml
+++ b/web/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "mapwisefox-web-backend"
-version = "0.9.1-dev1"
+version = "0.9.1"
 dependencies = [
     "arrow>=1.3.0",
     "authlib>=1.6.0",
@@ -32,7 +32,7 @@ module-name = "mapwisefox.web"
 namespace = true
 
 [tool.bumpversion]
-current_version = "0.9.1-dev1"
+current_version = "0.9.1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/web/backend/pyproject.toml
+++ b/web/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "mapwisefox-web-backend"
-version = "0.9.0"
+version = "0.9.1-dev1"
 dependencies = [
     "arrow>=1.3.0",
     "authlib>=1.6.0",
@@ -32,7 +32,7 @@ module-name = "mapwisefox.web"
 namespace = true
 
 [tool.bumpversion]
-current_version = "0.9.0"
+current_version = "0.9.1-dev1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/web/backend/src/mapwisefox/web/model/_repo.py
+++ b/web/backend/src/mapwisefox/web/model/_repo.py
@@ -17,6 +17,7 @@ from mapwisefox.web.model._evidence import Evidence
 type Decision = Literal["undecided", "included", "excluded"]
 
 LIST_SEPARATOR = ";"
+EXCLUSION_REASON_COLUMN_ALIASES = ("exclude_reason", "exclude_reasons")
 DECISION_VALUES: dict[str, Decision] = {
     "": "undecided",
     "include": "included",
@@ -115,6 +116,25 @@ def _validate_headers(values: list[Any], row: int) -> list[str]:
     return headers
 
 
+def _resolve_exclusion_reason_column(headers: list[str], column: str) -> str:
+    if column not in EXCLUSION_REASON_COLUMN_ALIASES or column in headers:
+        return column
+    return next(
+        (alias for alias in EXCLUSION_REASON_COLUMN_ALIASES if alias in headers), column
+    )
+
+
+def _exclusion_reason_value(values: dict[str, Any], column: str) -> Any:
+    columns = (
+        (column, *EXCLUSION_REASON_COLUMN_ALIASES)
+        if column in EXCLUSION_REASON_COLUMN_ALIASES
+        else (column,)
+    )
+    return next(
+        (values.get(name) for name in columns if not _is_blank(values.get(name))), None
+    )
+
+
 def _record_count(worksheet, header_row: int, width: int) -> int:
     rows = range(header_row + 1, worksheet.max_row + 1)
     populated = [
@@ -206,6 +226,9 @@ class WorkbookRepository:
                 )
             worksheet = workbook[selected_worksheet]
             header_row, headers = _headers(worksheet)
+            exclusion_reason_column = _resolve_exclusion_reason_column(
+                headers, exclusion_reason_column
+            )
             cls._validate_import_columns(
                 headers, field_mappings, decision_column, exclusion_reason_column
             )
@@ -369,7 +392,10 @@ class WorkbookRepository:
 
     def _exclusion_reason_col_index(self, worksheet) -> int:
         headers = self._current_headers(worksheet)
-        return headers.index(self.metadata.exclusion_reason_column) + 1
+        column = _resolve_exclusion_reason_column(
+            headers, self.metadata.exclusion_reason_column
+        )
+        return headers.index(column) + 1
 
     def _to_record(self, record_index: int, values: dict[str, Any]) -> ScreeningRecord:
         from mapwisefox.web.api.workbooks._cache import (
@@ -383,7 +409,12 @@ class WorkbookRepository:
             "" if _is_blank(decision_value) else str(decision_value).strip().lower()
         )
         reasons = Evidence._parse_list(
-            {"reasons": values[self.metadata.exclusion_reason_column]}, "reasons"
+            {
+                "reasons": _exclusion_reason_value(
+                    values, self.metadata.exclusion_reason_column
+                )
+            },
+            "reasons",
         )
         evidence_values = {
             _evidence_field(field): _mapped_value(

--- a/web/backend/tests/mapwisefox/test_web/api/workbooks/test_detail.py
+++ b/web/backend/tests/mapwisefox/test_web/api/workbooks/test_detail.py
@@ -1,4 +1,5 @@
 import asyncio
+from io import BytesIO
 
 import pytest
 from openpyxl import load_workbook
@@ -21,6 +22,29 @@ def test_screening_get_uses_zero_based_index(imported_client):
     assert response.status_code == 200
     assert response.json()["recordIndex"] == 0
     assert response.json()["decision"] == "undecided"
+
+
+def test_screening_get_returns_imported_reasons_without_selection_criteria(
+    client, workbook_file
+):
+    workbook = load_workbook(BytesIO(workbook_file))
+    worksheet = workbook["Studies"]
+    worksheet["K1"] = "include"
+    worksheet["L1"] = "exclude_reason"
+    worksheet["K2"] = "exclude"
+    worksheet["L2"] = "not software"
+    stream = BytesIO()
+    workbook.save(stream)
+    workbook.close()
+
+    client.post(
+        "/api/v1/workbooks",
+        files={"file": ("studies.xlsx", stream.getvalue())},
+        data={"worksheetName": "Studies"},
+    )
+    response = client.get("/api/v1/workbooks/studies.xlsx/screening/0")
+
+    assert response.json()["exclusionReasons"] == ["not software"]
 
 
 def test_screening_patch_persists_decision(imported_client, tmp_path):

--- a/web/backend/tests/mapwisefox/test_web/model/test_workbook_repo.py
+++ b/web/backend/tests/mapwisefox/test_web/model/test_workbook_repo.py
@@ -111,6 +111,56 @@ def test_import_appends_missing_screening_columns(imported_workbook):
     assert headers[-2:] == ["decision", "reason"]
 
 
+def test_import_reads_plural_exclusion_reason_column(source_workbook, tmp_path):
+    workbook = load_workbook(source_workbook)
+    worksheet = workbook["Studies"]
+    worksheet["L1"] = "exclude_reasons"
+    worksheet["L2"] = "not software;not english"
+    workbook.save(source_workbook)
+    workbook.close()
+
+    destination = tmp_path / "output.xlsx"
+    metadata = WorkbookRepository.import_workbook(
+        source_workbook, destination, "Studies", {}, "decision", "exclude_reason"
+    )
+
+    assert WorkbookRepository(destination, metadata).get(0).exclusion_reasons == [
+        "not software",
+        "not english",
+    ]
+
+
+def test_get_reads_plural_reasons_with_legacy_singular_metadata(
+    source_workbook, tmp_path
+):
+    workbook = load_workbook(source_workbook)
+    worksheet = workbook["Studies"]
+    worksheet["L1"] = "exclude_reasons"
+    worksheet["L2"] = "not software;not english"
+    workbook.save(source_workbook)
+    workbook.close()
+
+    destination = tmp_path / "output.xlsx"
+    metadata = WorkbookRepository.import_workbook(
+        source_workbook, destination, "Studies", {}, "decision", "exclude_reason"
+    )
+    workbook = load_workbook(destination)
+    workbook["Studies"]["N1"] = "exclude_reason"
+    workbook.save(destination)
+    workbook.close()
+
+    legacy_metadata = metadata.model_copy(
+        update={"exclusion_reason_column": "exclude_reason"}
+    )
+
+    assert WorkbookRepository(destination, legacy_metadata).get(
+        0
+    ).exclusion_reasons == [
+        "not software",
+        "not english",
+    ]
+
+
 def test_import_rejects_missing_mandatory_mapped_field(source_workbook, tmp_path):
     with pytest.raises(WorkbookValidationError, match="Missing") as error:
         WorkbookRepository.import_workbook(

--- a/web/frontend/.bumpversion.toml
+++ b/web/frontend/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.9.1-dev1"
+current_version = "0.9.1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/web/frontend/.bumpversion.toml
+++ b/web/frontend/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.9.0"
+current_version = "0.9.1-dev1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mapwisefox-web-frontend",
-  "version": "0.9.0-dev1",
+  "version": "0.9.1-dev1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mapwisefox-web-frontend",
-      "version": "0.9.0-dev1",
+      "version": "0.9.1-dev1",
       "dependencies": {
         "lucide-react": "^0.542.0",
         "react": "^19.1.1",

--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mapwisefox-web-frontend",
-  "version": "0.9.1-dev1",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mapwisefox-web-frontend",
-      "version": "0.9.1-dev1",
+      "version": "0.9.1",
       "dependencies": {
         "lucide-react": "^0.542.0",
         "react": "^19.1.1",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapwisefox-web-frontend",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1-dev1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapwisefox-web-frontend",
   "private": true,
-  "version": "0.9.1-dev1",
+  "version": "0.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/frontend/src/pages/EvidenceEditor.integration.test.tsx
+++ b/web/frontend/src/pages/EvidenceEditor.integration.test.tsx
@@ -106,6 +106,34 @@ describe("EvidenceEditor", () => {
         expect(screen.getByLabelText("study meets selection criteria")).toBeInTheDocument();
     });
 
+    it("shows an imported exclusion decision and its reasons", async () => {
+        const imported = {
+            ...screening(0),
+            decision: "excluded" as const,
+            exclusionReasons: ["not software"],
+            evidence: {...screening(0).evidence, include: true, excludeReasons: []},
+        };
+        vi.mocked(getScreening).mockResolvedValue(imported);
+        render(<EvidenceEditor evidence={imported.evidence} fileName="study.xlsx"/>);
+
+        expect(await screen.findByRole("button", {name: "Exclude"})).toBeInTheDocument();
+        expect(screen.getByText("not software")).toBeInTheDocument();
+    });
+
+    it("shows imported exclusion reasons without selection criteria", async () => {
+        const imported = {
+            ...screening(0, "Study 0", false),
+            decision: "included" as const,
+            exclusionReasons: ["not software"],
+            evidence: {...screening(0).evidence, include: false, excludeReasons: ["not software"]},
+        };
+        vi.mocked(getScreening).mockResolvedValue(imported);
+        render(<EvidenceEditor evidence={imported.evidence} fileName="study.xlsx"/>);
+
+        expect(await screen.findByRole("button", {name: "Exclude"})).toBeInTheDocument();
+        expect(screen.getByText("not software")).toBeInTheDocument();
+    });
+
     it("saves a decision and reports persistence errors", async () => {
         const user = userEvent.setup();
         render(<EvidenceEditor evidence={screening(0).evidence} fileName="study.xlsx"/>);

--- a/web/frontend/src/pages/EvidenceEditor.tsx
+++ b/web/frontend/src/pages/EvidenceEditor.tsx
@@ -36,6 +36,11 @@ async function fetchScreening(resource: string, index: number): Promise<Screenin
     }
 }
 
+function evidenceFromScreening({decision, exclusionReasons, evidence}: ScreeningResponse): EvidenceViewModel {
+    if (decision !== "excluded") return evidence;
+    return {...evidence, include: false, excludeReasons: exclusionReasons};
+}
+
 export default function EvidenceEditor({evidence, fileName}: EvidenceProps) {
     const [model, setModel] = useState<EvidenceViewModel>(evidence)
     const [screening, setScreening] = useState<ScreeningResponse | null>(null)
@@ -49,7 +54,7 @@ export default function EvidenceEditor({evidence, fileName}: EvidenceProps) {
         void fetchScreening(resource, Number(evidence.clusterId)).then(data => {
             if (data) {
                 setScreening(data)
-                setModel(data.evidence)
+                setModel(evidenceFromScreening(data))
             }
         })
     }, [evidence.clusterId, resource])
@@ -61,7 +66,7 @@ export default function EvidenceEditor({evidence, fileName}: EvidenceProps) {
             return;
         }
         setScreening(data)
-        setModel(data.evidence)
+        setModel(evidenceFromScreening(data))
         setError(null)
     }
 
@@ -88,7 +93,7 @@ export default function EvidenceEditor({evidence, fileName}: EvidenceProps) {
         try {
             const data = await updateScreening(resource, model.clusterId, decision, excludeReasons);
             setScreening(data)
-            setModel(data.evidence)
+            setModel(evidenceFromScreening(data))
             setError(null)
             const destination = data.nextUndecidedIndex ?? data.nextIndex
             if (destination !== null) await load(destination)


### PR DESCRIPTION
When importing a file without specifying selection criteria, it could be that the file already contains some include/exclude verdicts. This change makes it so that those previous exclusion reasons are still displayed in the UI.
Starting here, the app supports both the exclude_reason and exclude_reasons (plural) columns. This support is implemented in the UI both at import and at rendering.