### PR TITLE
Add CITATION.cff for easy import into Zenodo

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ abstract: "A suite of tools for performing systematic literature reviews and sys
 authors:
   - family-names: Olar
     given-names: Andrei
-version: 0.8.1-dev1
+version: 0.8.1
 date-released: "2026-07-27"
 repository-code: "https://github.com/koosie0507/mapwisefox"
 license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: MapwiseFox
+abstract: "A suite of tools for performing systematic literature reviews and systematic mapping studies."
+authors:
+  - family-names: Olar
+    given-names: Andrei
+version: 0.8.1-dev1
+date-released: "2026-07-27"
+repository-code: "https://github.com/koosie0507/mapwisefox"
+license: MIT
+keywords:
+  - systematic literature review
+  - systematic mapping study
+  - research synthesis
+  - information retrieval
+  - deduplication
+  - snowballing
+  - bibliography
+  - large language model tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox"
-version = "0.8.0"
+version = "0.8.1-dev1"
 description = "Utilities for creating systematic literature reviews"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -40,7 +40,7 @@ docs = [
 ]
 
 [tool.bumpversion]
-current_version = "0.8.0"
+current_version = "0.8.1-dev1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.
@@ -69,6 +69,11 @@ commit_args = ""
 setup_hooks = []
 pre_commit_hooks = []
 post_commit_hooks = []
+
+[[tool.bumpversion.files]]
+filename = "CITATION.cff"
+search = "version: {current_version}"
+replace = "version: {new_version}"
 
 [tool.bumpversion.parts.pre_label]
 values = ["dev", "final"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox"
-version = "0.8.1-dev1"
+version = "0.8.1"
 description = "Utilities for creating systematic literature reviews"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -40,7 +40,7 @@ docs = [
 ]
 
 [tool.bumpversion]
-current_version = "0.8.1-dev1"
+current_version = "0.8.1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.


### PR DESCRIPTION
- bump the version in the citation file every time we bump the version in the main pyproject.toml
- bump mapwisefox version: 0.8.0 → 0.8.1-dev1