### PR TITLE
fix small translation bugs in the Scopus and WoS adapters

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ abstract: "A suite of tools for performing systematic literature reviews and sys
 authors:
   - family-names: Olar
     given-names: Andrei
-version: 0.8.2-dev1
+version: 0.8.2
 date-released: "2026-07-27"
 repository-code: "https://github.com/koosie0507/mapwisefox"
 license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ abstract: "A suite of tools for performing systematic literature reviews and sys
 authors:
   - family-names: Olar
     given-names: Andrei
-version: 0.8.1
+version: 0.8.2-dev1
 date-released: "2026-07-27"
 repository-code: "https://github.com/koosie0507/mapwisefox"
 license: MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox"
-version = "0.8.2-dev1"
+version = "0.8.2"
 description = "Utilities for creating systematic literature reviews"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -40,7 +40,7 @@ docs = [
 ]
 
 [tool.bumpversion]
-current_version = "0.8.2-dev1"
+current_version = "0.8.2"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox"
-version = "0.8.1"
+version = "0.8.2-dev1"
 description = "Utilities for creating systematic literature reviews"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -40,7 +40,7 @@ docs = [
 ]
 
 [tool.bumpversion]
-current_version = "0.8.1"
+current_version = "0.8.2-dev1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/search/pyproject.toml
+++ b/search/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox-search"
-version = "0.7.1-dev1"
+version = "0.7.1"
 dependencies = [
     "arrow>=1.4.0",
     "clarivate-wos-starter-python-client",
@@ -23,7 +23,7 @@ package = true
 clarivate-wos-starter-python-client = { git = "https://github.com/clarivate/wosstarter_python_client.git" }
 
 [tool.bumpversion]
-current_version = "0.7.1-dev1"
+current_version = "0.7.1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/search/pyproject.toml
+++ b/search/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox-search"
-version = "0.7.0"
+version = "0.7.1-dev1"
 dependencies = [
     "arrow>=1.4.0",
     "clarivate-wos-starter-python-client",
@@ -23,7 +23,7 @@ package = true
 clarivate-wos-starter-python-client = { git = "https://github.com/clarivate/wosstarter_python_client.git" }
 
 [tool.bumpversion]
-current_version = "0.7.0"
+current_version = "0.7.1-dev1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/search/src/mapwisefox/search/backends/_scopus.py
+++ b/search/src/mapwisefox/search/backends/_scopus.py
@@ -44,7 +44,7 @@ class ScopusBackend(SearchBackend):
         return "; ".join(
             {
                 f"{author['given-name']}, {author['surname']}"
-                for author in entry["author"]
+                for author in entry.get("author", [])
             }
         )
 
@@ -81,8 +81,8 @@ class ScopusBackend(SearchBackend):
                 records.append(
                     {
                         "title": entry["dc:title"],
-                        "abstract": entry["dc:description"],
-                        "keywords": entry["authkeywords"].replace(" |", ";"),
+                        "abstract": entry.get("dc:description", ""),
+                        "keywords": entry.get("authkeywords", "").replace(" |", ";"),
                         "authors": self._get_authors(entry),
                         "source": entry["prism:publicationName"],
                         "doi": entry.get("prism:doi", "N/A"),

--- a/search/src/mapwisefox/search/dsl/adapters/_scopus.py
+++ b/search/src/mapwisefox/search/dsl/adapters/_scopus.py
@@ -53,7 +53,7 @@ class ScopusDSLAdapter(DSLAdapter):
         fields = self._get_all_node_fields(node)
         left_val = self._map_value(fields, node.left.value)
         right_val = self._map_value(fields, node.right.value)
-        term = f'"{left_val}" W/{node.distance} "{right_val}"'
+        term = f'("{left_val}" W/{node.distance} "{right_val}")'
         expr = self._emit_leaf_targets(fields, term)
         if node.fields:
             expr = self._apply_fields(expr, node.fields)

--- a/search/src/mapwisefox/search/dsl/adapters/_wos.py
+++ b/search/src/mapwisefox/search/dsl/adapters/_wos.py
@@ -63,7 +63,7 @@ class WebOfScienceDSLAdapter(DSLAdapter):
 
     def emit_near(self, node: NearExpr) -> Any:
         """Translate ``near[n](a, b)`` to the native ``NEAR/n`` operator."""
-        term = f'"{node.left.value}" NEAR/{node.distance} "{node.right.value}"'
+        term = f'("{node.left.value}" NEAR/{node.distance} "{node.right.value}")'
         fields = node.fields or self.field_ctx
 
         if self.output_ctx == OutputTarget.QUERY:
@@ -101,9 +101,13 @@ class WebOfScienceDSLAdapter(DSLAdapter):
         right = self._normalize(self.adapt(node.right))
 
         op = "AND" if node.op == BoolOp.AND else "OR"
-
         if left.query and right.query:
-            query_str = f"{left.query} {op} {right.query}"
+            if op == "AND" and right.query.startswith("NOT"):
+                query_str = f"{left.query} {right.query}"
+            elif op == "AND" and left.query.startswith("NOT"):
+                query_str = f"{right.query} {left.query}"
+            else:
+                query_str = f"{left.query} {op} {right.query}"
         else:
             query_str = left.query or right.query
 

--- a/uv.lock
+++ b/uv.lock
@@ -1488,7 +1488,7 @@ wheels = [
 
 [[package]]
 name = "mapwisefox"
-version = "0.8.0"
+version = "0.8.1"
 source = { virtual = "." }
 dependencies = [
     { name = "openai" },


### PR DESCRIPTION
* allow authors, abstract and keywords to be missing in the Scopus adapter
* always surround proximity matches with parentheses in the Scopus adapter
* handle NOT correctly in the WoS adapter (do not use AND NOT, simply use NOT)