### PR TITLE
assistant: loosen model choices

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ abstract: "A suite of tools for performing systematic literature reviews and sys
 authors:
   - family-names: Olar
     given-names: Andrei
-version: 0.9.2-dev1
+version: 0.9.2
 date-released: "2026-07-27"
 repository-code: "https://github.com/koosie0507/mapwisefox"
 license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ abstract: "A suite of tools for performing systematic literature reviews and sys
 authors:
   - family-names: Olar
     given-names: Andrei
-version: 0.9.1
+version: 0.9.2-dev1
 date-released: "2026-07-27"
 repository-code: "https://github.com/koosie0507/mapwisefox"
 license: MIT

--- a/assistant/pyproject.toml
+++ b/assistant/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox-assistant"
-version = "0.9.0"
+version = "0.10.0-dev1"
 dependencies = [
     "anthropic>=0.75.0",
     "bibtexparser>=1.4.3",
@@ -34,7 +34,7 @@ mapwisefox-common-config = { workspace = true }
 "*" = ["*.j2", "*.pth.tar"]
 
 [tool.bumpversion]
-current_version = "0.9.0"
+current_version = "0.10.0-dev1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/assistant/pyproject.toml
+++ b/assistant/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox-assistant"
-version = "0.10.0-dev1"
+version = "0.10.0"
 dependencies = [
     "anthropic>=0.75.0",
     "bibtexparser>=1.4.3",
@@ -34,7 +34,7 @@ mapwisefox-common-config = { workspace = true }
 "*" = ["*.j2", "*.pth.tar"]
 
 [tool.bumpversion]
-current_version = "0.10.0-dev1"
+current_version = "0.10.0"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/assistant/src/mapwisefox/assistant/_base.py
+++ b/assistant/src/mapwisefox/assistant/_base.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import click
 
-from mapwisefox.assistant.config import AssistantParams, ModelChoice, ProviderChoice
+from mapwisefox.assistant.config import AssistantParams, ProviderChoice
 from mapwisefox.assistant.config._validate import validate_config
 from mapwisefox.assistant.quality_assessment import cli as study_qa
 from mapwisefox.assistant.study_selection import cli as study_selection
@@ -15,9 +15,9 @@ from mapwisefox.assistant.tools.llm import (
 )
 
 
-def _ollama_provider(model_choice: str, ollama_host: str, ollama_port: int):
+def _ollama_provider(model_choice: str, ollama_endpoint: str, api_key: str):
     return partial(
-        OllamaProvider, model=model_choice, ollama_host=f"{ollama_host}:{ollama_port}"
+        OllamaProvider, model=model_choice, ollama_host=ollama_endpoint, api_key=api_key
     )
 
 
@@ -59,8 +59,8 @@ all assistant subcommands."""
 @click.option(
     "-m",
     "--model",
-    type=click.Choice(ModelChoice),
-    default=ModelChoice.gpt_oss,
+    type=click.STRING,
+    default="gpt-oss:20b",
     help="the name of the large language model to use",
     show_default=True,
 )
@@ -73,17 +73,10 @@ all assistant subcommands."""
     show_default=True,
 )
 @click.option(
-    "--ollama-host",
+    "--ollama-endpoint",
     type=click.STRING,
-    default="localhost",
-    help="host running Ollama",
-    show_default=True,
-)
-@click.option(
-    "--ollama-port",
-    type=click.IntRange(1024, 65535, clamp=True),
-    default=11434,
-    help="port on which Ollama is listening",
+    default="http://localhost:11434",
+    help="address where Ollama is listening",
     show_default=True,
 )
 @click.option(
@@ -95,11 +88,10 @@ all assistant subcommands."""
     default="",
 )
 @click.pass_context
-def assistant(ctx, model, provider, ollama_host, ollama_port, api_key):
+def assistant(ctx, model, provider, ollama_endpoint, api_key):
     obj = ctx.ensure_object(AssistantParams)
-    obj.model_choice = ModelChoice(model)
-    obj.ollama_host = ollama_host
-    obj.ollama_port = int(ollama_port)
+    obj.model_choice = model
+    obj.ollama_endpoint = ollama_endpoint
     obj.api_key = api_key
 
     match provider:
@@ -112,7 +104,7 @@ def assistant(ctx, model, provider, ollama_host, ollama_port, api_key):
         case ProviderChoice.bedrock:
             obj.provider_factory = _bedrock_provider(model, api_key)
         case _:
-            obj.provider_factory = _ollama_provider(model, ollama_host, ollama_port)
+            obj.provider_factory = _ollama_provider(model, ollama_endpoint, api_key)
 
 
 assistant.add_command(study_selection)

--- a/assistant/src/mapwisefox/assistant/config/__init__.py
+++ b/assistant/src/mapwisefox/assistant/config/__init__.py
@@ -11,11 +11,10 @@ from mapwisefox.common.config import (
     write_schema_files,
 )
 
-from ._types import ModelChoice, ProviderChoice, ReaderType, AssistantParams
+from ._types import ProviderChoice, ReaderType, AssistantParams
 
 
 __all__ = [
-    "ModelChoice",
     "ProviderChoice",
     "AssistantParams",
     "ReaderType",

--- a/assistant/src/mapwisefox/assistant/config/_types.py
+++ b/assistant/src/mapwisefox/assistant/config/_types.py
@@ -11,27 +11,6 @@ class ProviderChoice(StrEnum):
     bedrock = "aws-bedrock"
 
 
-class ModelChoice(StrEnum):
-    ministral = "ministral-3:14b"
-    qwen3_vl = "qwen3-vl:8b"
-    gpt_oss = "gpt-oss:20b"
-    gpt_oss_120b = "gpt-oss:120b"
-    deepseek = "deepseek-r1:14b"
-    llama = "llama3.1:8b"
-    qwen3 = "qwen3:8b"
-    gpt_52 = "gpt-5.2-2025-12-11"
-    gpt_5 = "gpt-5-2025-08-07"
-    gpt_5_mini = "gpt-5-mini-2025-08-07"
-    sonnet_4_5 = "claude-sonnet-4-5-20250929"
-    haiku_4_5 = "claude-haiku-4-5-20251001"
-    opus_4_5 = "claude-opus-4-5-20251101"
-    gemini_2_5_flash_lite = "gemini-2.5-flash-lite"
-    gemini_2_5_flash = "gemini-2.5-flash"
-    gemini_2_5_pro = "gemini-2.5-pro"
-    gemini_3_flash_preview = "gemini-3-flash-preview"
-    gemini_3_pro_preview = "gemini-3-pro-preview"
-
-
 class ReaderType(StrEnum):
     docling = "docling"
     custom = "custom"
@@ -40,7 +19,6 @@ class ReaderType(StrEnum):
 @dataclass
 class AssistantParams:
     provider_factory: Optional[Callable] = field(init=True, repr=True, default=None)
-    model_choice: ModelChoice = field(init=True, repr=True, default=ModelChoice.gpt_oss)
-    ollama_host: str = field(init=True, repr=True, default="localhost")
-    ollama_port: int = field(init=True, repr=True, default=11434)
+    model_choice: str = field(init=True, repr=True, default="gpt-oss:20b")
+    ollama_endpoint: str = field(init=True, repr=True, default="http://localhost:11434")
     api_key: Optional[str] = field(init=True, repr=True, default=None)

--- a/assistant/src/mapwisefox/assistant/quality_assessment/_study_qa.j2
+++ b/assistant/src/mapwisefox/assistant/quality_assessment/_study_qa.j2
@@ -1,27 +1,28 @@
-# TASK
+# PRIMARY STUDY QUALITY ASSESSMENT
 
-Evaluate the quality of the study following the '-----' delimiter line. It was
-selected as part of a systematic literature review on the following topic:
-"{{ topic }}".
+You are a reviewer that evaluates the quality of the study following the '-----'
+delimiter. The primary study is part of a systematic review on the topic: "{{ topic }}".
 
-Subsequent user prompts are conversational.
+## GENERAL RULES
 
-# EVALUATION CRITERIA
+I. NEVER INVENT FACTS OR ASSUMPTIONS!
+II. Avoid sycophantic behavior: be critical.
+
+## EVALUATION CRITERIA
 
 {{ description }}
 
 **Scoring Instructions: {{ scoring }}.**
 
-# OUTPUT REQUIREMENTS (STRICT)
+## OUTPUT REQUIREMENTS (STRICT)
 
-0. NEVER INVENT FACTS OR ASSUMPTIONS!
 1. Output MUST be valid JSON and NOTHING else.
 2. MUST SCORE the study in a way that complies to the scoring instructions.
 3. MUST provide a BRIEF JUSTIFICATION of the score.
 4. Assess quality ONLY on the study text provided.
 5. If information is insufficient to assess quality, assign the lowest justified score and state this in the reason.
 
-# EXAMPLES (FORMAT ONLY)
+## EXAMPLES (FORMAT ONLY)
 
 {"score": 1.2, "reason": "poor paper"}
 {"score": 8.8, "reason": "well-designed and clearly reported study"}

--- a/assistant/src/mapwisefox/assistant/quality_assessment/_study_qa.py
+++ b/assistant/src/mapwisefox/assistant/quality_assessment/_study_qa.py
@@ -1,5 +1,4 @@
 import io
-import logging
 import os
 from collections import defaultdict
 
@@ -333,9 +332,7 @@ def study_qa(
 
     download_dir = Path(download_dir).resolve()
     file = Path(file).resolve()
-    file_provider = FileProvider(
-        download_dir, verify_tls=not insecure_skip_tls_verify
-    )
+    file_provider = FileProvider(download_dir, verify_tls=not insecure_skip_tls_verify)
     pdf_reader = reader_factory(reader_type, layout_config_path)
 
     df = load_df(file, index_col=index_col)

--- a/assistant/src/mapwisefox/assistant/quality_assessment/_study_qa.py
+++ b/assistant/src/mapwisefox/assistant/quality_assessment/_study_qa.py
@@ -1,7 +1,6 @@
 import io
 import logging
 import os
-import sys
 from collections import defaultdict
 
 import pandas as pd
@@ -31,6 +30,7 @@ from mapwisefox.assistant.tools.callbacks import (
     write_stdout,
 )
 from mapwisefox.assistant.tools.extras import try_import
+from mapwisefox.assistant.tools.logging import get_logger
 from mapwisefox.assistant.tools.pdf import (
     FileContentsExtractor,
     CachingFileContentsExtractor,
@@ -38,9 +38,8 @@ from mapwisefox.assistant.tools.pdf import (
     ExtractionFailureReason,
 )
 
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-log = logging.getLogger(__file__)
-
+_COMMAND_NAME = "study-qa"
+log = get_logger(_COMMAND_NAME)
 urllib3.disable_warnings()
 
 
@@ -242,7 +241,7 @@ def _fill_results(df: pd.DataFrame, qa_criteria: dict, results: dict) -> pd.Data
 
 
 @click.command(
-    "study-qa",
+    _COMMAND_NAME,
     help=r"""Use an LLM to assess the quality of primary studies against criteria.
 
     FILE is an Excel spreadsheet with a column containing an URL (https:// or
@@ -306,6 +305,14 @@ def _fill_results(df: pd.DataFrame, qa_criteria: dict, results: dict) -> pd.Data
     default=False,
     help="disable TLS certificate verification when downloading primary study PDFs",
 )
+@click.option(
+    "-D",
+    "--download-dir",
+    "download_dir",
+    default=Path.cwd() / "downloads",
+    help="download directory where papers will be stored.",
+    show_default=True,
+)
 @click.pass_context
 def study_qa(
     ctx,
@@ -316,6 +323,7 @@ def study_qa(
     layout_config_path: str,
     reader_type: ReaderType,
     insecure_skip_tls_verify: bool,
+    download_dir: Path,
 ):
     try:
         qa_config = load_qa_config(qa_config_path).model_dump()
@@ -323,15 +331,20 @@ def study_qa(
         raise click.UsageError(str(err))
     qa_criteria = qa_config["criteria"]
 
+    download_dir = Path(download_dir).resolve()
     file = Path(file).resolve()
     file_provider = FileProvider(
-        file.parent / "downloads", verify_tls=not insecure_skip_tls_verify
+        download_dir, verify_tls=not insecure_skip_tls_verify
     )
     pdf_reader = reader_factory(reader_type, layout_config_path)
 
     df = load_df(file, index_col=index_col)
     for c in qa_criteria:
-        df[c["label"]] = df[c["label"]].astype("Float64")
+        column = c["label"]
+        if column in df.columns:
+            df[column] = pd.to_numeric(df[column], errors="coerce").astype("Float64")
+        else:
+            df[column] = pd.Series(dtype="Float64", index=df.index)
     expected_json_schema = {
         "title": "evaluation",
         "description": "primary study evaluation",
@@ -364,6 +377,10 @@ def study_qa(
     markdown_texts, failed = _extract_pdf_contents(
         df, url_column, file_provider, pdf_reader, default_reader, 1
     )
+    if failed:
+        log.warning("failed to download %d files", len(failed))
+        for f in failed:
+            log.warning(f)
     results = _evaluate_papers(markdown_texts, generate_json, qa_config, qa_criteria)
     df = _fill_results(df, qa_criteria, results)
     output_path = file.parent / f"{file.stem}-{ctx.obj.model_choice}{file.suffix}"

--- a/assistant/src/mapwisefox/assistant/study_selection/_study_selection.py
+++ b/assistant/src/mapwisefox/assistant/study_selection/_study_selection.py
@@ -4,6 +4,7 @@ from itertools import islice
 from pathlib import Path
 
 import click
+import pandas as pd
 from tenacity import (
     Retrying,
     stop_after_attempt,
@@ -22,6 +23,7 @@ from mapwisefox.assistant.tools.callbacks import (
 )
 from mapwisefox.assistant.tools.logging import get_logger
 
+_COMMAND_NAME = "study-selection"
 
 SYSTEM_PROMPT_TEMPLATE = Path(__file__).parent / f"{Path(__file__).stem}.j2"
 INCLUDE_COL_NAME = "include"
@@ -30,7 +32,7 @@ DEFAULT_EXCLUDED_ATTRIBUTES = ["cluster_id", INCLUDE_COL_NAME, EXCLUDE_REASON_CO
 _MAX_RETRIES = 3
 
 
-@click.command("study-selection")
+@click.command(_COMMAND_NAME)
 @click.argument(
     "search_results",
     required=True,
@@ -80,13 +82,16 @@ def study_selection(
     decides based whether each record meets a set of criteria (which are also
     provided by the user).
     """
-    logger = get_logger()
+    logger = get_logger(_COMMAND_NAME)
     ignored_attrs = set(
         ignore_attributes if len(ignore_attributes) > 0 else DEFAULT_EXCLUDED_ATTRIBUTES
     )
     search_results_path = Path(search_results)
     results_df = load_df(search_results_path, sheet_name=sheet_name)
-    results_df[INCLUDE_COL_NAME] = results_df[INCLUDE_COL_NAME].astype("string")
+    if INCLUDE_COL_NAME in results_df.columns:
+        results_df[INCLUDE_COL_NAME] = results_df[INCLUDE_COL_NAME].astype("string")
+    else:
+        results_df[INCLUDE_COL_NAME] = pd.Series(dtype="string", index=results_df.index)
 
     try:
         rule_config = load_selection_config(config_file)

--- a/assistant/src/mapwisefox/assistant/study_selection/_study_selection.py
+++ b/assistant/src/mapwisefox/assistant/study_selection/_study_selection.py
@@ -1,11 +1,16 @@
-import logging
 import os
-import sys
 from functools import partial
 from itertools import islice
 from pathlib import Path
 
 import click
+from tenacity import (
+    Retrying,
+    stop_after_attempt,
+    retry_if_exception_type,
+    wait_exponential,
+    sleep,
+)
 
 from mapwisefox.assistant.config import ConfigValidationError, load_selection_config
 from mapwisefox.common.config import SelectionResponse
@@ -15,13 +20,14 @@ from mapwisefox.assistant.tools.callbacks import (
     make_thinking_callback,
     write_stdout,
 )
-
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-log = logging.getLogger(__file__)
+from mapwisefox.assistant.tools.logging import get_logger
 
 
 SYSTEM_PROMPT_TEMPLATE = Path(__file__).parent / f"{Path(__file__).stem}.j2"
-DEFAULT_EXCLUDED_ATTRIBUTES = ["cluster_id", "include", "exclude_reason"]
+INCLUDE_COL_NAME = "include"
+EXCLUDE_REASON_COL_NAME = "exclude_reason"
+DEFAULT_EXCLUDED_ATTRIBUTES = ["cluster_id", INCLUDE_COL_NAME, EXCLUDE_REASON_COL_NAME]
+_MAX_RETRIES = 3
 
 
 @click.command("study-selection")
@@ -55,8 +61,18 @@ DEFAULT_EXCLUDED_ATTRIBUTES = ["cluster_id", "include", "exclude_reason"]
     default=DEFAULT_EXCLUDED_ATTRIBUTES,
     show_default=True,
 )
+@click.option(
+    "-s",
+    "--sheet-name",
+    type=click.STRING,
+    help="name of the worksheet containing the input records",
+    default=None,
+    show_default=False,
+)
 @click.pass_context
-def study_selection(ctx, search_results, config_file, limit, ignore_attributes):
+def study_selection(
+    ctx, search_results, config_file, limit, ignore_attributes, sheet_name
+):
     """Use an LLM to select primary studies according to criteria.
 
     A file containing a table of primary studies containing at least the title,
@@ -64,11 +80,13 @@ def study_selection(ctx, search_results, config_file, limit, ignore_attributes):
     decides based whether each record meets a set of criteria (which are also
     provided by the user).
     """
+    logger = get_logger()
     ignored_attrs = set(
         ignore_attributes if len(ignore_attributes) > 0 else DEFAULT_EXCLUDED_ATTRIBUTES
     )
     search_results_path = Path(search_results)
-    results_df = load_df(search_results_path)
+    results_df = load_df(search_results_path, sheet_name=sheet_name)
+    results_df[INCLUDE_COL_NAME] = results_df[INCLUDE_COL_NAME].astype("string")
 
     try:
         rule_config = load_selection_config(config_file)
@@ -76,7 +94,7 @@ def study_selection(ctx, search_results, config_file, limit, ignore_attributes):
         raise click.UsageError(str(err))
 
     provider = ctx.obj.provider_factory(
-        on_error=make_stderr_callback(log),
+        on_error=make_stderr_callback(logger),
         on_thinking=make_thinking_callback(),
         on_text=write_stdout,
     )
@@ -93,7 +111,8 @@ def study_selection(ctx, search_results, config_file, limit, ignore_attributes):
     )
 
     count = len(results_df) if limit is None else limit
-    items = islice(results_df.iterrows(), 0, count)
+    non_evaluated_records = results_df[results_df["include"].isna()]
+    items = islice(non_evaluated_records.iterrows(), 0, count)
 
     with click.progressbar(
         items,
@@ -103,19 +122,31 @@ def study_selection(ctx, search_results, config_file, limit, ignore_attributes):
         empty_char=click.style("-", fg="white", dim=True),
     ) as df_rows:
         for ix, row in df_rows:
-            row_str = os.linesep.join(
-                f"{key}: {value}"
-                for key, value in row.items()
-                if key not in ignored_attrs
-            )
-            answer_obj = generate_json(row_str)
-            status = answer_obj["answer"]
-            results_df.at[ix, "include"] = status
+            for retry_attempt in Retrying(
+                wait=wait_exponential(multiplier=2, max=4),
+                stop=stop_after_attempt(_MAX_RETRIES),
+                retry=retry_if_exception_type(Exception),
+            ):
+                with retry_attempt:
+                    row_str = os.linesep.join(
+                        f"{key}: {value}"
+                        for key, value in row.items()
+                        if key not in ignored_attrs
+                    )
+                    logger.info(
+                        "evaluating record %d /%d", ix + 1, len(non_evaluated_records)
+                    )
+                    answer_obj = generate_json(user_prompt=row_str)
+                    status = answer_obj["answer"]
+                    results_df.at[ix, "include"] = status
 
-            if status == "exclude":
-                results_df.at[ix, "exclude_reason"] = answer_obj["justification"]
-            elif status == "include":
-                results_df.at[ix, "exclude_reason"] = ""
+                    if status == "exclude":
+                        results_df.at[ix, "exclude_reason"] = answer_obj[
+                            "justification"
+                        ]
+                    elif status == "include":
+                        results_df.at[ix, "exclude_reason"] = ""
+                    sleep(1)
 
     model_stem = ctx.obj.model_choice.replace(":", "_")
     output_path = (

--- a/assistant/src/mapwisefox/assistant/tools/dataframe.py
+++ b/assistant/src/mapwisefox/assistant/tools/dataframe.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import pandas as pd
 from bibtexparser import load as load_bibtex
 from bibtexparser.bparser import BibTexParser
@@ -26,7 +28,7 @@ def _read_bibliography(path, index_col=None):
         return pd.DataFrame(records, index=index_col)
 
 
-def load_df(path, index_col=None):
+def load_df(path, index_col=None, sheet_name=None):
     """Load a ``.bib``, ``.csv`` or ``.xlsx`` file into a pandas DataFrame.
 
     Args:
@@ -40,7 +42,11 @@ def load_df(path, index_col=None):
     """
     fh = {
         ".bib": _read_bibliography,
-        ".xlsx": pd.read_excel,
+        ".xlsx": (
+            pd.read_excel
+            if sheet_name is None
+            else partial(pd.read_excel, sheet_name=sheet_name)
+        ),
         ".csv": pd.read_csv,
     }
     file_loader = fh.get(path.suffix)

--- a/assistant/src/mapwisefox/assistant/tools/llm/_bedrock.py
+++ b/assistant/src/mapwisefox/assistant/tools/llm/_bedrock.py
@@ -12,7 +12,6 @@ from tenacity import (
     stop_after_delay,
 )
 
-from mapwisefox.assistant.config import ModelChoice
 from mapwisefox.assistant.tools.extras import try_import
 from mapwisefox.assistant.tools.llm._provider import LLMProviderBase, JSONGenerator
 
@@ -243,14 +242,6 @@ class BedrockJSONGenerator(JSONGenerator):
 
 
 class BedrockProvider(LLMProviderBase):
-    MODEL_MAPPING = {
-        ModelChoice.haiku_4_5.value: "anthropic.claude-3-haiku-20240307-v1:0",
-        ModelChoice.sonnet_4_5.value: "anthropic.claude-sonnet-4-5-20250929-v1:0",
-        ModelChoice.opus_4_5.value: "anthropic.claude-opus-4-5-20251101-v1:0",
-        ModelChoice.gpt_oss: "openai.gpt-oss-20b-1:0",
-        ModelChoice.gpt_oss_120b: "openai.gpt-oss-120b-1:0",
-    }
-
     def __new__(cls, *args, **kwargs):
         obj = object.__new__(cls)
         if not hasattr(cls, "_guard") or not getattr(cls, "_guard"):
@@ -260,17 +251,15 @@ class BedrockProvider(LLMProviderBase):
             exceptions_module = try_import("botocore.exceptions")
             obj.ClientError = exceptions_module.ClientError
             obj.BotoCoreError = exceptions_module.BotoCoreError
-            obj.needs_region_prefix = kwargs.get("model") in {
-                ModelChoice.haiku_4_5,
-                ModelChoice.sonnet_4_5,
-                ModelChoice.opus_4_5,
-            }
+            obj.needs_region_prefix = str(kwargs.get("model") or "").startswith(
+                "anthropic."
+            )
             cls._guard = True
         return obj
 
     def __init__(self, model: str, api_key: str, **kwargs):
         super().__init__(
-            self.MODEL_MAPPING.get(model, model),
+            model,
             kwargs.pop("on_error", None),
             kwargs.pop("on_thinking", None),
             kwargs.pop("on_text", None),

--- a/assistant/src/mapwisefox/assistant/tools/llm/_ollama.py
+++ b/assistant/src/mapwisefox/assistant/tools/llm/_ollama.py
@@ -84,7 +84,10 @@ class OllamaProvider(LLMProviderBase):
             kwargs.pop("on_thinking", None),
             kwargs.pop("on_text", None),
         )
-        self.__client = self.Client(host=ollama_host)
+        headers = {}
+        if api_key := kwargs.pop("api_key", None):
+            headers["Authorization"] = f"Bearer {api_key}"
+        self.__client = self.Client(host=ollama_host, headers=headers)
 
     def _download_model(self) -> bool:
         try:

--- a/assistant/src/mapwisefox/assistant/tools/llm/_provider.py
+++ b/assistant/src/mapwisefox/assistant/tools/llm/_provider.py
@@ -47,7 +47,9 @@ class JSONGenerator(ABC):
         while not answered and attempts > 0:
             try:
                 system_prompt = system_prompt_template.render(**template_data)
-                llm_text = self._generate_text(system_prompt, user_prompt, response_schema or "json")
+                llm_text = self._generate_text(
+                    system_prompt, user_prompt, response_schema or "json"
+                )
                 answer_text = self.__regex.sub(r"\1", llm_text)
                 answer_obj = json.loads(answer_text)
                 answered = True

--- a/assistant/src/mapwisefox/assistant/tools/llm/_provider.py
+++ b/assistant/src/mapwisefox/assistant/tools/llm/_provider.py
@@ -24,6 +24,7 @@ class JSONGenerator(ABC):
         self._thinking_callback = on_thinking or self._no_op
         self._text_callback = on_text or self._no_op
         self.__max_retries = max_retries
+        self.__regex = re.compile(r"`+\w*\s*([{].+[}])\s*`+", re.M | re.S | re.U)
 
     @abstractmethod
     def _generate_text(
@@ -46,13 +47,8 @@ class JSONGenerator(ABC):
         while not answered and attempts > 0:
             try:
                 system_prompt = system_prompt_template.render(**template_data)
-                answer_text = re.sub(
-                    r"`+\w*[\s$]*(\{.+\})[$\s]*`+",
-                    r"\1",
-                    self._generate_text(
-                        system_prompt, user_prompt, response_schema or "json"
-                    ),
-                )
+                llm_text = self._generate_text(system_prompt, user_prompt, response_schema or "json")
+                answer_text = self.__regex.sub(r"\1", llm_text)
                 answer_obj = json.loads(answer_text)
                 answered = True
             except json.JSONDecodeError as err:

--- a/assistant/src/mapwisefox/assistant/tools/logging.py
+++ b/assistant/src/mapwisefox/assistant/tools/logging.py
@@ -1,0 +1,14 @@
+import logging
+import os
+import sys
+
+
+def get_logger(command_name):
+    log_level = os.getenv("MWF_LOG_LEVEL") or logging.INFO
+    logger = logging.getLogger(command_name)
+    logger.propagate = False
+    for h in logger.handlers:
+        logger.removeHandler(h)
+    logger.addHandler(logging.StreamHandler(sys.stdout))
+    logger.setLevel(log_level)
+    return logger

--- a/assistant/tests/mapwisefox/assistant/cli/conftest.py
+++ b/assistant/tests/mapwisefox/assistant/cli/conftest.py
@@ -10,7 +10,7 @@ import responses
 def sample_pdf_path():
     path = Path(__file__).parents[3] / "data" / "sample.pdf"
     assert path.exists(), f"sample PDF not found at {path}"
-    return path
+    yield path
 
 
 @pytest.fixture

--- a/assistant/tests/mapwisefox/assistant/cli/test_base.py
+++ b/assistant/tests/mapwisefox/assistant/cli/test_base.py
@@ -44,20 +44,3 @@ def test_assistant_requires_api_key_for_openai(
 
     assert result.exit_code != 0
     assert "API key" in result.output
-
-
-def test_assistant_clamps_ollama_port(runner, valid_selection_config_path):
-    result = runner.invoke(
-        assistant,
-        [
-            "--ollama-port",
-            "1",
-            "validate-config",
-            "--kind",
-            "study-selection",
-            "--config-file",
-            str(valid_selection_config_path),
-        ],
-    )
-
-    assert result.exit_code == 0

--- a/assistant/tests/mapwisefox/assistant/cli/test_canonical_study_qa.py
+++ b/assistant/tests/mapwisefox/assistant/cli/test_canonical_study_qa.py
@@ -1,11 +1,21 @@
+from pathlib import Path
+
 import pandas as pd
 import pytest
 import responses
 import openpyxl
+import shutil
 from unittest.mock import MagicMock
 
 from mapwisefox.assistant.config import AssistantParams
 from mapwisefox.assistant.quality_assessment._study_qa import study_qa
+
+
+@pytest.fixture(autouse=True)
+def cleanup_downloads_dir():
+    yield
+    downloads_dir = Path.cwd() / "downloads"
+    shutil.rmtree(downloads_dir, ignore_errors=True)
 
 
 @pytest.mark.parametrize("reader_type", ["custom", "docling"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox"
-version = "0.9.1"
+version = "0.9.2-dev1"
 description = "Utilities for creating systematic literature reviews"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -40,7 +40,7 @@ docs = [
 ]
 
 [tool.bumpversion]
-current_version = "0.9.1"
+current_version = "0.9.2-dev1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox"
-version = "0.9.2-dev1"
+version = "0.9.2"
 description = "Utilities for creating systematic literature reviews"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -40,7 +40,7 @@ docs = [
 ]
 
 [tool.bumpversion]
-current_version = "0.9.2-dev1"
+current_version = "0.9.2"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/uv.lock
+++ b/uv.lock
@@ -1488,7 +1488,7 @@ wheels = [
 
 [[package]]
 name = "mapwisefox"
-version = "0.9.1"
+version = "0.9.2.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "openai" },
@@ -1531,7 +1531,7 @@ docs = [
 
 [[package]]
 name = "mapwisefox-assistant"
-version = "0.9.0"
+version = "0.10.0.dev1"
 source = { editable = "assistant" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Allow specifying the model as free text instead of using a list of predefined choices per provider.

Bump assistant version: 0.9.0 → 0.10.0-dev1
Bump mapwisefox version: 0.9.1 → 0.9.2-dev1