### PR TITLE
Change "disable" weekly bucket to "enable" semantics

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ abstract: "A suite of tools for performing systematic literature reviews and sys
 authors:
   - family-names: Olar
     given-names: Andrei
-version: 0.9.5
+version: 0.9.6-dev1
 date-released: "2026-07-27"
 repository-code: "https://github.com/koosie0507/mapwisefox"
 license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ abstract: "A suite of tools for performing systematic literature reviews and sys
 authors:
   - family-names: Olar
     given-names: Andrei
-version: 0.9.6-dev1
+version: 0.9.6
 date-released: "2026-07-27"
 repository-code: "https://github.com/koosie0507/mapwisefox"
 license: MIT

--- a/docs/deduplication/getting-started/usage.md
+++ b/docs/deduplication/getting-started/usage.md
@@ -70,7 +70,7 @@ while Scopus results come straight from a live API call.
 
    See [Search → Installation](../../search/getting-started/installation.md#api-keys)
    for how to set `MWF_SEARCH_ELSEVIER_API_KEY`. `scopus.csv` lands in
-   `search`'s dated results directory (e.g. `data/search-results/20260720/`).
+   `search`'s results directory (e.g. `data/search-results/`).
 
 2. Paste the ACM query printed to your terminal into the ACM Digital
    Library's search UI, run it there, and use its **Export Citations →

--- a/docs/search/backends/science-direct.md
+++ b/docs/search/backends/science-direct.md
@@ -28,7 +28,7 @@
 | ---------- | ------------ | ------------------------------------------------------------------------------------------------------- |
 | `api_key`  | — (required) | `MWF_SEARCH_ELSEVIER_API_KEY`                                                                           |
 | `save`     | `True`       | Whether to persist results                                                                              |
-| `csv_path` | `None`       | Resolved relative to the dated results directory (see [Configuration](../configuration/config-file.md)) |
+| `csv_path` | `None`       | Resolved relative to the results directory (see [Configuration](../configuration/config-file.md)) |
 
 ## Output columns
 

--- a/docs/search/backends/scopus.md
+++ b/docs/search/backends/scopus.md
@@ -27,7 +27,7 @@
 | ----------- | ------------ | ------------------------------------------------ |
 | `api_key`   | — (required) | `MWF_SEARCH_ELSEVIER_API_KEY`                    |
 | `save`      | `True`       | Whether to persist results                       |
-| `csv_path`  | `None`       | Resolved relative to the dated results directory |
+| `csv_path`  | `None`       | Resolved relative to the results directory |
 | `fetch_all` | `True`       | Set `False` to fetch only the first page         |
 
 ## Output columns

--- a/docs/search/backends/springer.md
+++ b/docs/search/backends/springer.md
@@ -37,7 +37,7 @@ server-side query with a **client-side regex post-filter**.
 | Option      | Default      | Notes                                                                                           |
 | ----------- | ------------ | ----------------------------------------------------------------------------------------------- |
 | `api_key`   | — (required) | `MWF_SEARCH_SPRINGER_API_KEY`                                                                   |
-| `csv_path`  | `None`       | If set, `save_result` is automatically `True`; resolved relative to the dated results directory |
+| `csv_path`  | `None`       | If set, `save_result` is automatically `True`; resolved relative to the results directory |
 | `fetch_all` | `True`       | Set `False` to fetch only the first page                                                        |
 
 ## Output columns

--- a/docs/search/configuration/config-file.md
+++ b/docs/search/configuration/config-file.md
@@ -54,8 +54,8 @@ version control.
 ## Path resolution for backend options
 
 Two specific option keys get special treatment, resolved relative to the
-run's dated results directory (`<data-dir>/<results-dir-name>/<Monday's date>`,
-or just `<data-dir>/<results-dir-name>` with `--disable-weekly-bucket`):
+run's results directory (`<data-dir>/<results-dir-name>/`, or
+`<data-dir>/<results-dir-name>/<Monday's date>` with `--enable-weekly-bucket`):
 
 - `csv_path`: wrapped as-is, resolved relative to that directory.
 - `persistence_adapter`: if given as a string/path, it's wrapped in a
@@ -64,7 +64,7 @@ or just `<data-dir>/<results-dir-name>` with `--disable-weekly-bucket`):
 
 This happens in `_resolve_backend_options` in `__main__.py`, _after_ env var
 expansion — so `csv_path: ${OUT_DIR}/scopus.csv` would expand the env var
-first, then still be joined onto the dated results directory (this
+first, then still be joined onto the results directory (this
 combination is unusual and likely not what you want — prefer a bare relative
 filename for `csv_path` in normal use).
 

--- a/docs/search/configuration/persistence.md
+++ b/docs/search/configuration/persistence.md
@@ -18,7 +18,7 @@ with.
 Most API backends build their own `PandasCsvAdapter` internally from a
 `csv_path` constructor option (see each backend's page in
 [Backends](../backends/overview.md)) — `csv_path` is resolved relative to
-the dated results directory by `__main__.py` before being passed to the
+the results directory by `__main__.py` before being passed to the
 backend's constructor.
 
 `WebOfScienceBackend` is the exception: it takes a `persistence_adapter`

--- a/docs/search/getting-started/cli-reference.md
+++ b/docs/search/getting-started/cli-reference.md
@@ -16,7 +16,7 @@ uv run search --help
 | `--data-dir`, `-D` | `DATA_DIR` | `./data` | Root directory results are written under. |
 | `--max-workers` | — | `3` | Maximum number of backends to run concurrently (applies only to non-console backends). |
 | `--debug`, `-d` | — | `False` | Print detailed errors from all backends, and log per-backend error tracebacks after a run. |
-| `--disable-weekly-bucket` | — | `False` | Skip the `<YYYYMMDD of most recent Monday>` subdirectory and write straight into `<data-dir>/<results-dir-name>/`. |
+| `--enable-weekly-bucket` | — | `False` | Add a `<YYYYMMDD of most recent Monday>` subdirectory under `--results-dir-name` where results are written. |
 | `--results-dir-name` | — | `search-results` | Subdirectory name within `--data-dir` where results are written. |
 
 ## Execution model

--- a/docs/search/getting-started/usage.md
+++ b/docs/search/getting-started/usage.md
@@ -102,19 +102,19 @@ There's a few things that are different compared to the first, basic example:
 
 - **`backend.type` + `backend.options`**: Instead of a bare string like `ConsoleBackend`, live backends need constructor options — at minimum an `api_key`, and usually a `csv_path` to specify where results are written (see [Configuration](../configuration/config-file.md)).
 - **Execution order**: Live API backends (anything other than `ConsoleBackend` or `WebOfScienceBackend` with `use_starter_api: false`) run **concurrently** after console backends finish, bounded by `--max-workers` (default 3). See [CLI Reference](cli-reference.md#execution-model) for the full diagram.
-- **Output**: Results are written to CSV files under `<data-dir>/<results-dir-name>/<YYYYMMDD of most recent Monday>/`.
+- **Output**: Results are written to CSV files under `<data-dir>/<results-dir-name>/` (or `<data-dir>/<results-dir-name>/<YYYYMMDD of most recent Monday>/` when `--enable-weekly-bucket` is passed).
 
 For other backends (ScienceDirect, Scopus, Web of Science, ACM, IEEE Xplore), see the [Backends](../backends/overview.md) section for endpoint details, constructor options, and output schemas.
 
 If the query is successful, you'll see the search results in the following directory:
 
 ```
-<data-dir>/<results-dir-name>/<YYYYMMDD of the most recent Monday>/
+<data-dir>/<results-dir-name>/
 ```
 
 - `--data-dir` defaults to `./data` (env: `DATA_DIR`)
 - `--results-dir-name` defaults to `search-results`
-- The weekly-Monday bucket means re-running `search` multiple times in the same week overwrites the same output directory — handy for iterating on a query without accumulating stale CSVs. Pass `--disable-weekly-bucket` to turn this off and write straight into `<data-dir>/<results-dir-name>/`.
+- Pass `--enable-weekly-bucket` to add a `<YYYYMMDD of most recent Monday>` subdirectory under `--results-dir-name`. This makes re-running `search` multiple times in the same week overwrite the same dated output directory — handy for iterating on a query without accumulating stale CSVs.
 
 Relative `csv_path`s or `persistence_adapter` paths in a backend's options are resolved **relative to the results directory**.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox"
-version = "0.9.6-dev1"
+version = "0.9.6"
 description = "Utilities for creating systematic literature reviews"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -40,7 +40,7 @@ docs = [
 ]
 
 [tool.bumpversion]
-current_version = "0.9.6-dev1"
+current_version = "0.9.6"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox"
-version = "0.9.5"
+version = "0.9.6-dev1"
 description = "Utilities for creating systematic literature reviews"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -40,7 +40,7 @@ docs = [
 ]
 
 [tool.bumpversion]
-current_version = "0.9.5"
+current_version = "0.9.6-dev1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/search/config.example.yaml
+++ b/search/config.example.yaml
@@ -27,8 +27,9 @@
 # String option values are passed through os.path.expandvars, so
 # `${MY_ENV_VAR}` (or a .env file, loaded automatically) can be used to avoid
 # committing secrets such as API keys. The backend options `csv_path` and
-# `persistence_adapter` are resolved relative to this run's dated input
-# directory (<data-dir>/input/<YYYYMMDD of the most recent Monday>); for
+# `persistence_adapter` are resolved relative to this run's results directory
+# (<data-dir>/<results-dir-name>/, or <data-dir>/<results-dir-name>/<YYYYMMDD of
+# the most recent Monday>/ when --enable-weekly-bucket is set); for
 # `persistence_adapter`, the path is wrapped in a PandasCsvAdapter.
 #
 # Backends using ConsoleBackend always run first, sequentially (so their

--- a/search/pyproject.toml
+++ b/search/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox-search"
-version = "0.8.1"
+version = "0.9.0-dev1"
 dependencies = [
     "arrow>=1.4.0",
     "clarivate-wos-starter-python-client",
@@ -23,7 +23,7 @@ package = true
 clarivate-wos-starter-python-client = { git = "https://github.com/clarivate/wosstarter_python_client.git" }
 
 [tool.bumpversion]
-current_version = "0.8.1"
+current_version = "0.9.0-dev1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/search/pyproject.toml
+++ b/search/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox-search"
-version = "0.9.0-dev1"
+version = "0.9.0"
 dependencies = [
     "arrow>=1.4.0",
     "clarivate-wos-starter-python-client",
@@ -23,7 +23,7 @@ package = true
 clarivate-wos-starter-python-client = { git = "https://github.com/clarivate/wosstarter_python_client.git" }
 
 [tool.bumpversion]
-current_version = "0.9.0-dev1"
+current_version = "0.9.0"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/search/src/mapwisefox/search/__main__.py
+++ b/search/src/mapwisefox/search/__main__.py
@@ -94,11 +94,11 @@ def _execute(spec: BackendSpec, ir: QueryIR, input_dir: Path) -> None:
     help=r"""
 Runs configured search backends against the specified query and saves results.
 
-The results are written under <data-dir>/<results-dir-name>/<week start date>.
-The week start date is the date the most recent Monday falls on. Running search
-multiple times during the same week overwrites previous results by default. This
-enables rapid iteration. This behaviour can be turned off using the
---disable-weekly-bucket flag.
+The results are written under <data-dir>/<results-dir-name>/. Pass
+--enable-weekly-bucket to add a <week start date> subdirectory, where the week
+start date is the date the most recent Monday falls on. Running search multiple
+times during the same week with --enable-weekly-bucket overwrites previous
+results, which enables rapid iteration.
 """,
 )
 @click.option(
@@ -131,11 +131,11 @@ enables rapid iteration. This behaviour can be turned off using the
     help="If set, detailed errors from all backends will be printed.",
 )
 @click.option(
-    "--disable-weekly-bucket",
-    "disable_weekly",
+    "--enable-weekly-bucket",
+    "enable_weekly",
     is_flag=True,
     default=False,
-    help="If set, results will be written to the --results-dir-name subdirectory.",
+    help="If set, results are written under a <YYYYMMDD of most recent Monday> subdirectory of --results-dir-name.",
 )
 @click.option(
     "--results-dir-name",
@@ -147,7 +147,7 @@ def main(
     data_dir: str | Path,
     max_workers: int,
     debug: bool,
-    disable_weekly: bool,
+    enable_weekly: bool,
     results_dir_name: str,
 ):
     logging.basicConfig(
@@ -156,9 +156,7 @@ def main(
     )
 
     config = _load_config(config_path)
-    search_results_dir = _ensure_results_dir(
-        data_dir, results_dir_name, not disable_weekly
-    )
+    search_results_dir = _ensure_results_dir(data_dir, results_dir_name, enable_weekly)
 
     assert config.query is not None  # guaranteed by SearchConfig validation
     parser = Parser()

--- a/search/tests/mapwisefox/search/test_cli.py
+++ b/search/tests/mapwisefox/search/test_cli.py
@@ -139,10 +139,10 @@ def test_main_data_dir_override(tmp_path, adapter, backend):
 @pytest.mark.parametrize(
     ("extra_args", "expected_use_weekly_buckets"),
     [
-        ([], True),
-        (["--disable-weekly-bucket"], False),
+        ([], False),
+        (["--enable-weekly-bucket"], True),
     ],
-    ids=["default-uses-weekly-bucket", "flag-disables-weekly-bucket"],
+    ids=["default-no-weekly-bucket", "flag-enables-weekly-bucket"],
 )
 def test_main_weekly_bucket_wiring(tmp_path, extra_args, expected_use_weekly_buckets):
     runner = CliRunner()

--- a/uv.lock
+++ b/uv.lock
@@ -1488,7 +1488,7 @@ wheels = [
 
 [[package]]
 name = "mapwisefox"
-version = "0.9.5.dev1"
+version = "0.9.6.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "openai" },
@@ -1623,7 +1623,7 @@ requires-dist = [
 
 [[package]]
 name = "mapwisefox-search"
-version = "0.8.1"
+version = "0.9.0.dev1"
 source = { editable = "search" }
 dependencies = [
     { name = "arrow" },

--- a/uv.lock
+++ b/uv.lock
@@ -1488,7 +1488,7 @@ wheels = [
 
 [[package]]
 name = "mapwisefox"
-version = "0.9.6.dev1"
+version = "0.9.6"
 source = { virtual = "." }
 dependencies = [
     { name = "openai" },
@@ -1623,7 +1623,7 @@ requires-dist = [
 
 [[package]]
 name = "mapwisefox-search"
-version = "0.9.0.dev1"
+version = "0.9.0"
 source = { editable = "search" }
 dependencies = [
     { name = "arrow" },


### PR DESCRIPTION
The parameter --disable-weekly-bucket was confusing and the default behaviour of having a weekly bucket is probably
counterintuitive to most people. Changed the default behaviour to the opposite. Changed the flag name to --enable-weekly-bucket.

This PR also updates the associated mkdocs documentation.