### PR TITLE
add GitHub pages support 

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -11,12 +11,12 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # we need history & tags to avoid duplicates
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Check version & create tag if final
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Install node
         uses: actions/setup-node@v6
@@ -34,9 +34,9 @@ jobs:
   version-final:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.1
       - name: Assert version is FINAL (no prerelease)
         shell: bash
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'   # built only for version tags
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to rebuild/push image for (e.g. v0.9.6)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -13,29 +19,54 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Resolve tag and detect prereleases
+        id: tag
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            ref="refs/tags/${{ inputs.tag }}"
+          else
+            ref="${{ github.ref }}"
+          fi
+          tag="${ref#refs/tags/}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          if [[ "$tag" == *-* ]]; then
+            echo "Prerelease detected ($tag); skipping image push."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - if: steps.tag.outputs.skip != 'true'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
+      - if: steps.tag.outputs.skip != 'true'
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - if: steps.tag.outputs.skip != 'true'
+        name: Log in to GHCR
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
+      - if: steps.tag.outputs.skip != 'true'
+        name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=tag
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
+      - if: steps.tag.outputs.skip != 'true'
+        name: Build and push
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: backend-runtime

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,90 @@
+name: Docs (on tag)
+
+# Publishes versioned MkDocs documentation to GitHub Pages via mike.
+#
+# Triggers:
+#   - push of a `v*` tag: builds that tag's docs and deploys to gh-pages as
+#     `<tag>` plus the `latest` alias; root URL redirects to `latest`.
+#   - workflow_dispatch with `tag` input: rebuild/redeploy an existing tag
+#     (useful to refresh old docs after mkdocs config/theme changes).
+#
+# Prerelease tags (e.g. v0.9.6-rc1, v0.9.6-dev1) are skipped.
+#
+# One-time manual setup (cannot be done from a workflow without an admin PAT):
+#   After the first successful run creates the `gh-pages` branch, go to
+#   Repo Settings -> Pages -> Build and deployment -> Source: Deploy from a
+#   branch, then select branch `gh-pages` and folder `/root`.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to rebuild docs for (e.g. v0.9.6)'
+        required: true
+        type: string
+
+permissions:
+  contents: write  # mike pushes commits to the gh-pages branch
+
+concurrency:
+  group: docs-pages
+  cancel-in-progress: false  # never interrupt an in-flight gh-pages push
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag and detect prereleases
+        id: tag
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            ref="refs/tags/${{ inputs.tag }}"
+          else
+            ref="${{ github.ref }}"
+          fi
+          tag="${ref#refs/tags/}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          if [[ "$tag" == *-* ]]; then
+            echo "Prerelease detected ($tag); skipping publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.tag.outputs.skip != 'true'
+        name: Checkout (full history + gh-pages for mike)
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - if: steps.tag.outputs.skip != 'true'
+        name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+
+      - if: steps.tag.outputs.skip != 'true'
+        name: Configure git identity for mike commits
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - if: steps.tag.outputs.skip != 'true'
+        name: Sync docs dependencies
+        run: uv sync --only-group docs --active
+
+      - if: steps.tag.outputs.skip != 'true'
+        name: Fetch existing gh-pages (mike needs a local copy in shallow clones)
+        run: git fetch origin gh-pages --depth=1 || true
+
+      - if: steps.tag.outputs.skip != 'true'
+        name: Deploy version + 'latest' alias to gh-pages
+        env:
+          GIT_AUTHOR_NAME:     github-actions[bot]
+          GIT_AUTHOR_EMAIL:    41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME:  github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: make prepare-pages VERSION=${{ steps.tag.outputs.tag }}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ abstract: "A suite of tools for performing systematic literature reviews and sys
 authors:
   - family-names: Olar
     given-names: Andrei
-version: 0.10.0-dev1
+version: 0.10.0
 date-released: "2026-07-27"
 repository-code: "https://github.com/koosie0507/mapwisefox"
 license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ abstract: "A suite of tools for performing systematic literature reviews and sys
 authors:
   - family-names: Olar
     given-names: Andrei
-version: 0.9.6
+version: 0.10.0-dev1
 date-released: "2026-07-27"
 repository-code: "https://github.com/koosie0507/mapwisefox"
 license: MIT

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ PYTHON_TEST_DIRS := $(addsuffix /tests,$(PYTHON_PACKAGE_DIRS))
 VALID_PACKAGES := $(PYTHON_PACKAGE_DIRS) $(WEB_FRONTEND_DIR)
 BUMP_KIND := $(or $(VERSION_COMPONENT),pre_label)
 
-.PHONY: .check-deps bootstrap clean format check test
+.PHONY: .check-deps bootstrap clean format check test \
+       build-docs serve-docs prepare-pages clean-docs
 
 .check-deps:
 	@command -v git >/dev/null 2>&1 || { echo "Error: 'git' is not installed or not in PATH." >&2; exit 1; }
@@ -106,3 +107,32 @@ re-tag: .check-deps
 	git tag --delete $(TAG) && \
 	git tag $(TAG) && \
 	git push --tags
+
+# ---------------------------------------------------------------------------
+# Documentation
+# ---------------------------------------------------------------------------
+# build-docs: strict local build for verification (output in ./_site).
+# serve-docs: local dev server with live reload (single version).
+# prepare-pages: deploy current checkout to gh-pages as VERSION + 'latest' alias.
+#   Requires VERSION, e.g. `make prepare-pages VERSION=v0.9.6`. Pushes to origin.
+# clean-docs: remove local build output.
+#
+# Docs targets sync only the `docs` dependency group (mkdocs-material,
+# mkdocstrings, include-markdown, mike) rather than the full workspace.
+
+build-docs:
+	uv sync --only-group docs --active
+	uv run --active mkdocs build --strict --site-dir _site
+
+serve-docs:
+	uv sync --only-group docs --active
+	uv run --active mkdocs serve --strict
+
+prepare-pages:
+	@test -n "$(VERSION)" || { echo "VERSION required (e.g. make prepare-pages VERSION=v0.9.6)"; exit 1; }
+	uv sync --only-group docs --active
+	uv run --active mike deploy --update-aliases --push "$(VERSION)" latest
+	uv run --active mike set-default latest --push
+
+clean-docs:
+	rm -rf _site

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: MapwiseFox
 site_description: Systematic literature review tooling
+site_url: https://koosie0507.github.io/mapwisefox/
 repo_url: https://github.com/koosie0507/mapwisefox
 edit_uri: edit/main/docs/
 
@@ -23,6 +24,10 @@ theme:
 
 extra_css:
   - stylesheets/extra.css
+
+extra:
+  version:
+    provider: mike
 
 markdown_extensions:
   - admonition
@@ -54,6 +59,9 @@ plugins:
             docstring_style: google
             show_source: true
             show_root_heading: true
+  - mike:
+      version_selector: true
+      canonical_version: latest
 
 nav:
   - Home: index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox"
-version = "0.10.0-dev1"
+version = "0.10.0"
 description = "Utilities for creating systematic literature reviews"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -41,7 +41,7 @@ docs = [
 ]
 
 [tool.bumpversion]
-current_version = "0.10.0-dev1"
+current_version = "0.10.0"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapwisefox"
-version = "0.9.6"
+version = "0.10.0-dev1"
 description = "Utilities for creating systematic literature reviews"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -37,10 +37,11 @@ docs = [
     "mkdocs-material>=9.5",
     "mkdocstrings[python]>=0.26",
     "mkdocs-include-markdown-plugin>=6.2",
+    "mike>=2.1",
 ]
 
 [tool.bumpversion]
-current_version = "0.9.6"
+current_version = "0.10.0-dev1"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/uv.lock
+++ b/uv.lock
@@ -1488,7 +1488,7 @@ wheels = [
 
 [[package]]
 name = "mapwisefox"
-version = "0.9.6"
+version = "0.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "openai" },

--- a/uv.lock
+++ b/uv.lock
@@ -1505,6 +1505,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "mike" },
     { name = "mkdocs-include-markdown-plugin" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -1524,6 +1525,7 @@ dev = [
     { name = "ruff", specifier = ">=0.14" },
 ]
 docs = [
+    { name = "mike", specifier = ">=2.1" },
     { name = "mkdocs-include-markdown-plugin", specifier = ">=6.2" },
     { name = "mkdocs-material", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26" },
@@ -1891,6 +1893,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d5/1e/094ace9d518f425e0cd189bf00b2acc7656eca20bd3f3bede1272468ac6c/meta_paper-0.7.0.tar.gz", hash = "sha256:8cf4e4dfdb3e0534c48422380ed9e8d2dbdbf58008ea86fa70733e8c6c82699b", size = 7515, upload-time = "2026-08-14T21:05:46.567Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/b4/90846e0214787f45ea4dc8abeb6f3f41731fbac050c2c7bde1c234a29756/meta_paper-0.7.0-py3-none-any.whl", hash = "sha256:78d4f060889e26293b8be8a7e7ac582095b8a47b2a4fb37b31ace6d00c67f978", size = 11358, upload-time = "2026-08-14T21:05:45.608Z" },
+]
+
+[[package]]
+name = "mike"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "verspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/47/fa87e9d56bef16cdfe34b059a437e8c6f7ec6f1b9c378871c3cf95ebea9c/mike-2.2.0.tar.gz", hash = "sha256:1e3858e32c0f125aac14432fc7848434358f9ae0962c5c5cde387ad47f6ad25e", size = 38450, upload-time = "2026-04-14T04:59:03.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/8e/56ccb09c7232a55403a7637caa21922f3b65901a37f5e8bdb405d0de0946/mike-2.2.0-py3-none-any.whl", hash = "sha256:e1f4981c1152eec7c2490a3401142292cc47d686194188416db2648fdfe1d040", size = 34026, upload-time = "2026-04-14T04:59:02.602Z" },
 ]
 
 [[package]]
@@ -4304,6 +4323,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Publish the mkdocs documentation on each tag push -- or on demand. Allow users to switch to different versions of the documentation using `mike`. 